### PR TITLE
Add equipment status tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,11 +34,17 @@
           <div class="card-header">
             <div>
               <h2>Find equipment</h2>
-              <p>Search by equipment name or current location.</p>
+              <p>Search by equipment name, location, or status.</p>
             </div>
-            <div class="filter">
-              <label for="location-filter">Location</label>
-              <select id="location-filter"></select>
+            <div class="filters">
+              <div class="filter">
+                <label for="location-filter">Location</label>
+                <select id="location-filter"></select>
+              </div>
+              <div class="filter">
+                <label for="status-filter">Status</label>
+                <select id="status-filter"></select>
+              </div>
             </div>
           </div>
           <div class="search">
@@ -55,6 +61,7 @@
                 <tr>
                   <th>Equipment</th>
                   <th>Location</th>
+                  <th>Status</th>
                   <th>Last moved</th>
                 </tr>
               </thead>
@@ -87,6 +94,10 @@
                 <select id="move-location"></select>
               </label>
               <label>
+                Status (optional)
+                <select id="move-status"></select>
+              </label>
+              <label>
                 Notes (optional)
                 <input id="move-notes" type="text" placeholder="Customer name, demo date..." />
               </label>
@@ -102,6 +113,10 @@
               <label>
                 Starting location
                 <select id="new-equipment-location"></select>
+              </label>
+              <label>
+                Status
+                <select id="new-equipment-status"></select>
               </label>
               <button type="submit">Add equipment</button>
             </form>

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,12 @@ h1 {
   flex-wrap: wrap;
 }
 
+.filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .filter label {
   font-size: 12px;
   color: var(--muted);
@@ -345,6 +351,11 @@ button:hover {
   color: var(--success);
   font-weight: 600;
   font-size: 12px;
+}
+
+.tag--status {
+  background: rgba(75, 110, 245, 0.12);
+  color: var(--accent-dark);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Separate equipment status from physical location so items can be tracked by both a physical place and a lifecycle/status value (e.g. On hire, In calibration). 

### Description
- Add canonical physical locations (`Perth`, `Melbourne`, `Brisbane`, `Sydney`, `New Zealand`) and a `statusOptions` list, update demo seed items to include `status` values and sensible mappings (e.g. previous "On hire" items now have `status: "On hire"` and a physical location). 
- Normalize loaded state to ensure all equipment have a valid `location` and `status` (derive `On hire` status from old `On hire` location and default other items to `Available`). 
- Add UI elements: Status dropdown filter next to Location (includes `All statuses`), a Status column with badge styling in the equipment table, a Status selector in the "Log a move" form (includes a "Keep current status" option) and a Status selector on the "Add new equipment" form. 
- Update counters and filtering logic so `Tracked items` remains total equipment and `On hire` counts items where `status === "On hire"`, and ensure search/filtering and history messages include status changes. 
- Style changes: add `.filters` layout and `.tag--status` to match existing pill visuals. Files changed: `app.js`, `index.html`, `styles.css`.

### Testing
- Smoke-launched a static server with `python -m http.server 8000` and exercised the UI via a Playwright script that loaded `/index.html` and produced a screenshot; the Playwright run completed and produced an artifact at `artifacts/equipment-tracker-status.png` (smoke test succeeded). 
- No unit tests added; all behavior checks performed via the served application smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c6e821aec8333856cb25b501cbb84)