### PR TITLE
Fix equipment table column alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -316,7 +316,7 @@ function renderTable() {
 
   if (filtered.length === 0) {
     elements.equipmentTable.innerHTML =
-      '<tr><td colspan="4">No equipment matches the current filter.</td></tr>';
+      '<tr><td colspan="7">No equipment matches the current filter.</td></tr>';
     return;
   }
 
@@ -325,9 +325,6 @@ function renderTable() {
       (item) => {
         const ageLabel = getAgeLabel(item.purchaseDate, now);
         const calibrationInfo = getCalibrationInfo(item, now);
-        const calibrationStatusClass = calibrationInfo.status
-          .toLowerCase()
-          .replace(/\s+/g, "-");
         const calibrationMeta = calibrationInfo.dueDate
           ? `Due ${formatDate(calibrationInfo.dueDate)}`
           : item.calibrationRequired
@@ -342,9 +339,12 @@ function renderTable() {
             item.status
           )}</span></td>
           <td><span class="tag">${escapeHTML(item.location)}</span></td>
-          <td><span class="tag tag--status">${escapeHTML(
-            item.status
-          )}</span></td>
+          <td>
+            <div><span class="tag tag--status">${escapeHTML(
+              calibrationInfo.status
+            )}</span></div>
+            <div>${escapeHTML(calibrationMeta)}</div>
+          </td>
           <td>${escapeHTML(item.lastMoved)}</td>
         </tr>
       `;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                   <th>Serial</th>
                   <th>Status</th>
                   <th>Location</th>
-                  <th>Status</th>
+                  <th>Calibration</th>
                   <th>Last moved</th>
                 </tr>
               </thead>


### PR DESCRIPTION
### Motivation
- The equipment table header and rows were misaligned with a duplicated `Status` column and mis-ordered cells, causing header labels to not match row data.

### Description
- Update `index.html` to set the table header columns to the required order: `Equipment`, `Model`, `Serial`, `Status`, `Location`, `Calibration`, `Last moved` by replacing the duplicate `Status` header with `Calibration`.
- Update `app.js` `renderTable()` to output seven `<td>` cells per row in the matching order, render `Model` as the model text, `Location` as the location pill, and `Calibration` as the calibration badge/status plus meta text, and remove the duplicate status cell.
- Adjust the empty-state row `colspan` from `4` to `7` to match the updated column count and remove the now-unused `calibrationStatusClass` variable.

### Testing
- Launched a local dev server with `python -m http.server` and ran an automated Playwright snapshot script which saved a visual snapshot at `artifacts/equipment-table.png`, and the script completed successfully.
- Ran repository searches (`rg`) to verify the header and rendering code locations were updated and there were no remaining duplicate `Status` header occurrences, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806b11c5008333bd3f8a3a3800d80c)