### PR TITLE
Replace duplicate Status column with Calibration column

### DIFF
--- a/app.js
+++ b/app.js
@@ -350,7 +350,7 @@ function renderTable() {
   if (filtered.length === 0) {
     if (elements.equipmentTable) {
       elements.equipmentTable.innerHTML =
-        '<tr><td colspan="4">No equipment matches the current filter.</td></tr>';
+        '<tr><td colspan="7">No equipment matches the current filter.</td></tr>';
     }
     return;
   }
@@ -361,14 +361,20 @@ function renderTable() {
         (item) => {
           const ageLabel = getAgeLabel(item.purchaseDate, now);
           const calibrationInfo = getCalibrationInfo(item, now);
-          const calibrationStatusClass = calibrationInfo.status
-            .toLowerCase()
-            .replace(/\s+/g, "-");
           const calibrationMeta = calibrationInfo.dueDate
             ? `Due ${formatDate(calibrationInfo.dueDate)}`
             : item.calibrationRequired
               ? "Last calibration needed"
               : "No calibration required";
+          const hasCalibrationData =
+            item.calibrationRequired !== undefined ||
+            item.calibrationIntervalMonths !== undefined ||
+            item.lastCalibrationDate;
+          const calibrationCell = hasCalibrationData
+            ? `<span class="tag tag--status" title="${escapeHTML(
+                calibrationMeta
+              )}">${escapeHTML(calibrationInfo.status)}</span>`
+            : "—";
           return `
         <tr>
           <td>${escapeHTML(item.name)}</td>
@@ -378,9 +384,7 @@ function renderTable() {
             item.status
           )}</span></td>
           <td><span class="tag">${escapeHTML(item.location)}</span></td>
-          <td><span class="tag tag--status">${escapeHTML(
-            item.status
-          )}</span></td>
+          <td>${calibrationCell}</td>
           <td>${escapeHTML(item.lastMoved)}</td>
         </tr>
       `;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                   <th>Serial</th>
                   <th>Status</th>
                   <th>Location</th>
-                  <th>Status</th>
+                  <th>Calibration</th>
                   <th>Last moved</th>
                 </tr>
               </thead>


### PR DESCRIPTION
### Motivation
- Remove a duplicated “Status” column in the equipment table and replace it with a “Calibration” column. 
- Ensure header and row cell order matches: `Equipment, Model, Serial, Status, Location, Calibration, Last moved`.
- Show a placeholder when calibration data is not yet implemented for an item.

### Description
- Updated the table header in `index.html` to replace the second `Status` heading with `Calibration` and preserve the required column order. 
- Modified `renderTable` in `app.js` to compute calibration details using existing `getCalibrationInfo`, produce a `calibrationCell` and insert it into the correct column instead of duplicating the status cell. 
- When calibration fields are not present for an item the cell renders the placeholder `—`. 
- Adjusted the empty-state row `colspan` in `app.js` from `4` to `7` to match the new column count.

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded `index.html` to exercise the UI, which started successfully. 
- Captured a page screenshot using a Playwright script to verify the table layout visually, which completed successfully. 
- Changes were committed locally; no failing automated tests were produced during these steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69814f036d0883338f2f0bbef1cf17c5)