### PR TITLE
Update seeded demo equipment calibration data

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ function buildDefaultState() {
         lastMoved: "2024-05-12 16:45",
         calibrationRequired: false,
         calibrationIntervalMonths: 12,
-        lastCalibrationDate: "",
+        lastCalibrationDate: getSeedDate({ months: -6 }),
       },
       {
         id: crypto.randomUUID(),
@@ -65,9 +65,9 @@ function buildDefaultState() {
         location: "Perth",
         status: "On hire",
         lastMoved: "2024-05-10 11:00",
-        calibrationRequired: false,
+        calibrationRequired: true,
         calibrationIntervalMonths: 12,
-        lastCalibrationDate: "",
+        lastCalibrationDate: getSeedDate({ months: -14 }),
       },
       {
         id: crypto.randomUUID(),
@@ -80,7 +80,7 @@ function buildDefaultState() {
         lastMoved: "2024-05-11 13:25",
         calibrationRequired: true,
         calibrationIntervalMonths: 12,
-        lastCalibrationDate: getSeedDate({ months: -8 }),
+        lastCalibrationDate: getSeedDate({ months: -10, days: -5 }),
       },
     ],
     history: [


### PR DESCRIPTION
### Motivation
- Ensure all seeded demo equipment items include realistic `model`, `serialNumber`, `purchaseDate`, `calibrationRequired`, `calibrationIntervalMonths`, and `lastCalibrationDate` values. 
- Produce a mix of calibration outcomes so the demo shows one `OK`, one `Due soon` (within 60 days), one `Overdue`, and one `Not required`. 
- Preserve the UI/layout and rely on the existing computed calibration column rather than hard-coded status values.

### Description
- Updated seeded entries in `buildDefaultState()` inside `app.js`: set `lastCalibrationDate` for the Audio demo case to `getSeedDate({ months: -6 })` (calibration not required), changed Lighting rig to `calibrationRequired: true` with `lastCalibrationDate: getSeedDate({ months: -14 })` (Overdue), and adjusted Portable control unit `lastCalibrationDate` to `getSeedDate({ months: -10, days: -5 })` (Due soon); Projection kit kept at `getSeedDate({ months: -3 })` (OK). 
- Left the rendering and table layout untouched so the calibration column continues to reflect the result of `getCalibrationInfo(item, now)`. 
- Only `app.js` was modified to update the demo/default state values.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981937150c083339133688507253336)