### PR TITLE
Add calibration fields to Add Equipment form and persist settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,8 +129,20 @@ const elements = {
   addEquipmentCalibrationInterval: document.querySelector(
     "#new-equipment-calibration-interval"
   ),
+  addEquipmentCalibrationIntervalCustom: document.querySelector(
+    "#new-equipment-calibration-interval-custom"
+  ),
+  addEquipmentCalibrationIntervalField: document.querySelector(
+    "#new-equipment-calibration-interval-field"
+  ),
+  addEquipmentCalibrationIntervalCustomField: document.querySelector(
+    "#new-equipment-calibration-interval-custom-field"
+  ),
   addEquipmentLastCalibration: document.querySelector(
     "#new-equipment-last-calibration"
+  ),
+  addEquipmentLastCalibrationField: document.querySelector(
+    "#new-equipment-last-calibration-field"
   ),
   addLocationForm: document.querySelector("#add-location-form"),
   addLocationName: document.querySelector("#new-location-name"),
@@ -648,12 +660,11 @@ function handleAddEquipment(event) {
   const location = elements.addEquipmentLocation.value;
   const status = elements.addEquipmentStatus.value;
   const calibrationRequired =
-    elements.addEquipmentCalibrationRequired?.checked ?? false;
-  const calibrationInterval = Number(
-    elements.addEquipmentCalibrationInterval?.value ?? 12
-  );
-  const lastCalibrationDate =
-    elements.addEquipmentLastCalibration?.value ?? "";
+    elements.addEquipmentCalibrationRequired?.checked ?? true;
+  const calibrationInterval = getSelectedCalibrationInterval();
+  const lastCalibrationDate = calibrationRequired
+    ? elements.addEquipmentLastCalibration?.value ?? ""
+    : "";
   if (!name) {
     return;
   }
@@ -682,10 +693,13 @@ function handleAddEquipment(event) {
   elements.addEquipmentSerial.value = "";
   elements.addEquipmentPurchaseDate.value = "";
   if (elements.addEquipmentCalibrationRequired) {
-    elements.addEquipmentCalibrationRequired.checked = false;
+    elements.addEquipmentCalibrationRequired.checked = true;
   }
   if (elements.addEquipmentCalibrationInterval) {
     elements.addEquipmentCalibrationInterval.value = "12";
+  }
+  if (elements.addEquipmentCalibrationIntervalCustom) {
+    elements.addEquipmentCalibrationIntervalCustom.value = "";
   }
   if (elements.addEquipmentLastCalibration) {
     elements.addEquipmentLastCalibration.value = "";
@@ -695,17 +709,61 @@ function handleAddEquipment(event) {
   syncCalibrationInputs();
 }
 
+function getSelectedCalibrationInterval() {
+  const calibrationRequired =
+    elements.addEquipmentCalibrationRequired?.checked ?? true;
+  if (!calibrationRequired) {
+    return 12;
+  }
+  const intervalSelection =
+    elements.addEquipmentCalibrationInterval?.value ?? "12";
+  if (intervalSelection === "custom") {
+    const customValue = Number(
+      elements.addEquipmentCalibrationIntervalCustom?.value ?? ""
+    );
+    if (Number.isFinite(customValue) && customValue > 0) {
+      return customValue;
+    }
+    return 12;
+  }
+  const parsed = Number(intervalSelection);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 12;
+}
+
 function syncCalibrationInputs() {
   if (
     !elements.addEquipmentCalibrationRequired ||
     !elements.addEquipmentCalibrationInterval ||
-    !elements.addEquipmentLastCalibration
+    !elements.addEquipmentLastCalibration ||
+    !elements.addEquipmentCalibrationIntervalCustom
   ) {
     return;
   }
   const isRequired = elements.addEquipmentCalibrationRequired.checked;
+  const isCustom =
+    elements.addEquipmentCalibrationInterval.value === "custom";
   elements.addEquipmentCalibrationInterval.disabled = !isRequired;
+  elements.addEquipmentCalibrationIntervalCustom.disabled =
+    !isRequired || !isCustom;
   elements.addEquipmentLastCalibration.disabled = !isRequired;
+  if (elements.addEquipmentCalibrationIntervalField) {
+    elements.addEquipmentCalibrationIntervalField.classList.toggle(
+      "is-hidden",
+      !isRequired
+    );
+  }
+  if (elements.addEquipmentCalibrationIntervalCustomField) {
+    elements.addEquipmentCalibrationIntervalCustomField.classList.toggle(
+      "is-hidden",
+      !isRequired || !isCustom
+    );
+  }
+  if (elements.addEquipmentLastCalibrationField) {
+    elements.addEquipmentLastCalibrationField.classList.toggle(
+      "is-hidden",
+      !isRequired
+    );
+  }
 }
 
 function handleAddLocation(event) {
@@ -767,6 +825,13 @@ if (elements.addEquipmentForm) {
 
 if (elements.addEquipmentCalibrationRequired) {
   elements.addEquipmentCalibrationRequired.addEventListener(
+    "change",
+    syncCalibrationInputs
+  );
+}
+
+if (elements.addEquipmentCalibrationInterval) {
+  elements.addEquipmentCalibrationInterval.addEventListener(
     "change",
     syncCalibrationInputs
   );

--- a/index.html
+++ b/index.html
@@ -133,6 +133,39 @@
                 Status
                 <select id="new-equipment-status"></select>
               </label>
+              <label class="checkbox-field">
+                Calibration required
+                <input
+                  id="new-equipment-calibration-required"
+                  type="checkbox"
+                  checked
+                />
+              </label>
+              <label id="new-equipment-calibration-interval-field">
+                Calibration interval
+                <select id="new-equipment-calibration-interval">
+                  <option value="12">12 months</option>
+                  <option value="24">24 months</option>
+                  <option value="custom">Custom</option>
+                </select>
+              </label>
+              <label
+                id="new-equipment-calibration-interval-custom-field"
+                class="is-hidden"
+              >
+                Custom interval (months)
+                <input
+                  id="new-equipment-calibration-interval-custom"
+                  type="number"
+                  min="1"
+                  step="1"
+                  placeholder="e.g. 18"
+                />
+              </label>
+              <label id="new-equipment-last-calibration-field">
+                Last calibration date
+                <input id="new-equipment-last-calibration" type="date" />
+              </label>
               <button type="submit">Add equipment</button>
             </form>
 

--- a/styles.css
+++ b/styles.css
@@ -303,6 +303,10 @@ tr:last-child td {
   justify-self: start;
 }
 
+.is-hidden {
+  display: none;
+}
+
 button {
   border: none;
   border-radius: 10px;


### PR DESCRIPTION
### Motivation
- Capture calibration preferences on new equipment items so the tracker can show calibration status and due dates per item.
- Allow teams to opt out of calibration, choose standard intervals or a custom interval, and record the last calibration date separately from `purchaseDate`.

### Description
- Added form inputs in `index.html` for `Calibration required` (checkbox default checked), `Calibration interval` (12/24/custom) with a custom months number input, and `Last calibration date` (date input). 
- Added `.is-hidden` CSS utility to `styles.css` for conditional hiding of form fields. 
- Updated `app.js` to reference the new elements, added `getSelectedCalibrationInterval()` to resolve selected/custom intervals, and wired `syncCalibrationInputs()` to enable/disable and show/hide interval and last-calibration fields when calibration is not required or when `custom` is selected. 
- Persisted calibration fields on new equipment objects via `handleAddEquipment()` using `normalizeCalibrationFields()` so `calibrationRequired`, `calibrationIntervalMonths`, and `lastCalibrationDate` are stored with sensible defaults when calibration is not required. 
- Ensured table rendering still uses `getCalibrationInfo()` so the Calibration column updates immediately based on the saved fields and respects the new inputs.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the app and the server started successfully. 
- Attempted an automated Playwright screenshot to verify the form UI, but the browser run failed with a `TargetClosedError` / SIGSEGV so no screenshot was produced; no other automated tests were present or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981944ab9e08333ad62a0cac82617b6)