### PR TITLE
Add record calibration workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,33 @@
               <button type="submit">Record move</button>
             </form>
 
+            <form id="calibration-form" class="panel">
+              <h3>Record calibration</h3>
+              <label>
+                Equipment
+                <select id="calibration-equipment"></select>
+              </label>
+              <label>
+                Calibration date
+                <input id="calibration-date" type="date" />
+              </label>
+              <label>
+                Interval months (optional override)
+                <input
+                  id="calibration-interval"
+                  type="number"
+                  min="1"
+                  step="1"
+                  placeholder="e.g. 18"
+                />
+              </label>
+              <label class="checkbox-field">
+                Calibration required
+                <input id="calibration-required" type="checkbox" />
+              </label>
+              <button type="submit">Save calibration</button>
+            </form>
+
             <form id="add-equipment-form" class="panel">
               <h3>Add new equipment</h3>
               <label>


### PR DESCRIPTION
### Motivation
- Provide a way to record calibration for an equipment item from the Console panel so users can update `lastCalibrationDate` and optionally the calibration interval without leaving the dashboard.
- Allow users to explicitly toggle `calibrationRequired` rather than silently flipping it when recording calibration.
- Keep the new control visually consistent with existing dashboard panels and reuse existing state/persistence logic.

### Description
- Added a new `Record calibration` panel to `index.html` with controls for `calibration-equipment`, `calibration-date`, `calibration-interval`, and `calibration-required` wrapped in the same `panel` styling as other console forms. 
- Wired new DOM references in `app.js` (`calibrationForm`, `calibrationEquipment`, `calibrationDate`, `calibrationInterval`, `calibrationRequired`) and populated `calibration-equipment` via the existing `renderEquipmentOptions()` routine. 
- Implemented `syncCalibrationForm()` to pre-fill the date (defaulting to today) and `calibrationRequired` from the selected item, and added a `handleCalibrationSubmit()` to set `item.lastCalibrationDate`, optionally update `item.calibrationIntervalMonths` if an interval is provided, apply the user-controlled `calibrationRequired` value, log the change, call `saveState()`, and `refreshUI()`. 
- Hooked up event listeners for form submit and equipment change, and ensured UI refresh calls include calibration form sync so the table re-renders and state persists consistently.

### Testing
- Launched a local dev server with `python -m http.server 8000` and opened the app with Playwright to capture a visual smoke-test screenshot, and the script completed successfully. 
- Verified the new form renders alongside other Console panels in the captured screenshot (artifact: `artifacts/record-calibration.png`).
- Did not run an automated end-to-end scenario to mark an overdue item as calibrated and verify persistence; that manual QA step remains to be performed (no failure observed in the automated smoke test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698196253dd88333b9324f47b9bff24d)