### PR TITLE
Fix calibration equipment dropdown to use canonical equipment list

### DIFF
--- a/app.js
+++ b/app.js
@@ -288,18 +288,47 @@ function renderStatusOptions() {
 }
 
 function renderEquipmentOptions() {
-  const options = state.equipment
-    .map(
-      (item) =>
-        `<option value="${item.id}">${escapeHTML(item.name)}</option>`
-    )
+  const equipmentList = state.equipment;
+  populateEquipmentSelect(
+    elements.moveEquipment,
+    equipmentList,
+    elements.moveEquipment?.value
+  );
+  populateEquipmentSelect(
+    elements.calibrationEquipment,
+    equipmentList,
+    elements.calibrationEquipment?.value
+  );
+}
+
+function populateEquipmentSelect(selectEl, equipmentList, selectedId) {
+  if (!selectEl) {
+    return;
+  }
+  const list = Array.isArray(equipmentList) ? equipmentList : [];
+  if (!list.length) {
+    selectEl.innerHTML =
+      '<option value="" disabled selected>No equipment found</option>';
+    return;
+  }
+  const options = list
+    .map((item) => {
+      const name = item.name?.trim() ? item.name : "";
+      const modelLabel = item.model?.trim() ? item.model : "—";
+      const serialLabel = item.serialNumber?.trim()
+        ? item.serialNumber
+        : "—";
+      const label = `${name} — ${modelLabel} — ${serialLabel}`;
+      return `<option value="${escapeHTML(
+        item.id
+      )}">${escapeHTML(label)}</option>`;
+    })
     .join("");
-  if (elements.moveEquipment) {
-    elements.moveEquipment.innerHTML = options;
-  }
-  if (elements.calibrationEquipment) {
-    elements.calibrationEquipment.innerHTML = options;
-  }
+  selectEl.innerHTML = options;
+  const selectedValue = list.some((item) => item.id === selectedId)
+    ? selectedId
+    : list[0].id;
+  selectEl.value = selectedValue;
 }
 
 function renderStats() {


### PR DESCRIPTION
### Motivation
- The calibration equipment dropdown was not consistently listing the current equipment and needed to use the same canonical equipment array as the move dropdown so both stay in sync.

### Description
- Add a shared helper `populateEquipmentSelect(selectEl, equipmentList, selectedId)` that renders options with `value` set to the equipment `id` and labels in the format `${name} — ${model || '—'} — ${serialNumber || '—'}`.
- Update `renderEquipmentOptions()` to populate both `elements.moveEquipment` and `elements.calibrationEquipment` from the canonical `state.equipment` via the new helper, preserving the previous selection when present.
- Render a single disabled option `No equipment found` when the equipment list is empty.
- Dropdowns are refreshed whenever `refreshUI()` runs (which is invoked after state load/normalization and after handlers that call `saveState()` such as `handleAddEquipment`, `handleMoveSubmit`, and `handleCalibrationSubmit`) so the calibration select updates immediately after equipment changes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698197aab8a083339f39ee47abe1c362)