### PR TITLE
Remove calibration statuses from equipment dropdowns and normalize legacy statuses

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,8 +14,6 @@ const statusOptions = [
   "On hire",
   "In transit",
   "In service / repair",
-  "Calibration due",
-  "In calibration",
   "Quarantined",
 ];
 
@@ -27,6 +25,22 @@ const calibrationFilterOptions = [
   "Unknown",
   "Not required",
 ];
+
+function normalizeStatus(rawStatus, rawLocation) {
+  const status = typeof rawStatus === "string" ? rawStatus.trim() : "";
+  if (status && /calibration/i.test(status)) {
+    return "Quarantined";
+  }
+  if (statusOptions.includes(status)) {
+    return status;
+  }
+  const location =
+    typeof rawLocation === "string" ? rawLocation.trim().toLowerCase() : "";
+  if (location === "on hire") {
+    return "On hire";
+  }
+  return "Available";
+}
 
 function getSeedDate({ months = 0, days = 0 } = {}) {
   const date = new Date();
@@ -200,11 +214,10 @@ function loadState() {
       if (rawLocation && !locationSet.has(rawLocation)) {
         locationSet.add(rawLocation);
       }
-      const derivedStatus = statusOptions.includes(normalizedItem.status)
-        ? normalizedItem.status
-        : rawLocation.toLowerCase() === "on hire"
-          ? "On hire"
-          : "Available";
+      const derivedStatus = normalizeStatus(
+        normalizedItem.status,
+        rawLocation
+      );
 
       return {
         ...normalizedItem,


### PR DESCRIPTION
### Motivation
- Prevent calibration-related words appearing in the equipment status pickers and filters and ensure calibration is represented only by the computed calibration fields.
- Migrate legacy items that used calibration-related statuses into a safe allowed status during load so persisted data is normalized.

### Description
- Removed calibration-related status entries (`"Calibration due"`, `"In calibration"`) from the allowed `statusOptions` list in `app.js` so status dropdowns only include the approved values.
- Added `normalizeStatus(rawStatus, rawLocation)` to map any legacy status containing the word "calibration" to `"Quarantined"` and otherwise preserve or infer a valid status (infers `"On hire"` from location, defaults to `"Available"`).
- Replaced the previous derived-status logic in `loadState()` to call `normalizeStatus(...)` so migrated states are persisted back to localStorage.
- Left calibration UI (filters/fields) and calibration computed logic untouched so calibration reminders remain driven by the computed calibration columns/filters.

### Testing
- Launched a local HTTP server and used a headless Playwright script to open the page and capture a screenshot of the status dropdown, confirming calibration-related options are not present (succeeded).
- Inspected the modified `app.js` to confirm calibration statuses were removed from `statusOptions` and `normalizeStatus` was added and used during load (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819c5deb6083338848fcafc051279b)