### PR TITLE
Lock locations to canonical list and remove Add location UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
 
         <section class="card">
           <h2>Console</h2>
-          <p>Use the console to log moves, add new equipment, or introduce a new location.</p>
+          <p>Use the console to log moves or add new equipment.</p>
 
           <div class="console">
             <form id="move-form" class="panel">
@@ -208,14 +208,6 @@
               <button type="submit">Add equipment</button>
             </form>
 
-            <form id="add-location-form" class="panel">
-              <h3>Add a location</h3>
-              <label>
-                Location name
-                <input id="new-location-name" type="text" required />
-              </label>
-              <button type="submit">Add location</button>
-            </form>
           </div>
 
           <div class="history">


### PR DESCRIPTION
### Motivation
- Prevent users from creating custom locations in the Console UI and treat locations as a fixed canonical list.
- Ensure all location dropdowns (filters, add equipment, edit/move flows) are backed by the same fixed list: Perth, Melbourne, Brisbane, Sydney, New Zealand.
- Normalize stored state to avoid breakage from user-added locations and to map any unknown equipment location to a safe default.

### Description
- Removed the "Add a location" panel from the Console markup and updated the console copy in `index.html` so the UI no longer exposes adding locations.
- Removed DOM lookups and the add-location submit handler in `app.js` so there is no client-side path to introduce new locations.
- Changed `loadState()` to ignore any persisted `locations` array and always use the `physicalLocations` constant; equipment locations not in the canonical list are mapped to `Perth` and an optional history entry is added describing the correction.
- Kept rendering logic intact so all selects (`locationFilter`, `move-location`, `new-equipment-location`, etc.) are populated from `state.locations` which is now the fixed canonical list, and preserved existing styling/layout.

### Testing
- Launched a lightweight HTTP server with `python -m http.server` and ran a Playwright script to load the app and capture a screenshot at `artifacts/location-console.png`; the script completed successfully and the captured page shows the Console without an add-location panel.
- The Playwright navigation and screenshot step completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819d289348833388005df39fc6e41d)