### PR TITLE
Add history entry for equipment detail edits

### DIFF
--- a/app.js
+++ b/app.js
@@ -1150,6 +1150,27 @@ function handleEditEquipmentSubmit(event) {
     lastCalibrationDate,
   });
 
+  const updatedFields = {
+    name,
+    model,
+    serialNumber,
+    purchaseDate,
+    location,
+    status,
+    calibrationRequired: calibrationDetails.calibrationRequired,
+    calibrationIntervalMonths:
+      calibrationDetails.calibrationIntervalMonths,
+    lastCalibrationDate: calibrationDetails.lastCalibrationDate,
+  };
+  const changedFields = Object.keys(updatedFields).filter((field) => {
+    const currentValue = item[field];
+    const nextValue = updatedFields[field];
+    if (typeof currentValue === "number" || typeof nextValue === "number") {
+      return Number(currentValue) !== Number(nextValue);
+    }
+    return currentValue !== nextValue;
+  });
+
   item.name = name;
   item.model = model;
   item.serialNumber = serialNumber;
@@ -1160,6 +1181,14 @@ function handleEditEquipmentSubmit(event) {
   item.calibrationIntervalMonths =
     calibrationDetails.calibrationIntervalMonths;
   item.lastCalibrationDate = calibrationDetails.lastCalibrationDate;
+
+  if (changedFields.length > 0) {
+    logHistory(
+      `Details updated for ${name} (${item.id}): ${changedFields.join(
+        ", "
+      )}.`
+    );
+  }
 
   saveState();
   refreshUI();


### PR DESCRIPTION
### Motivation
- When equipment records are edited the app should append a concise log entry indicating an update occurred with timestamp, equipment id/name and which fields changed, without storing previous values.

### Description
- Compute an `updatedFields` object inside `handleEditEquipmentSubmit` and derive `changedFields` by comparing current and new values, coercing numeric comparisons where needed.
- Append a history entry via `logHistory` with the format `Details updated for <name> (<id>): <field1, field2, ...>.` only when at least one field changed.
- Preserve existing history shape (`id`, `text`, `timestamp`) so rendering via `renderHistory` continues to work without changes.
- No old values are stored; only field names are listed in the message.

### Testing
- Launched a local server with `python -m http.server` and confirmed the app page loads by taking an automated page screenshot; the page render check succeeded.
- Attempted an automated UI edit using Playwright to change a field and detect the new history entry, but the Playwright edit-run timed out or failed due to environment/browser issues so the edit simulation did not complete.
- Code changes were lint/committed successfully and manual inspection verifies `logHistory` is used consistently and `renderHistory` remains compatible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819fd5e6748333b8e48590032b6b30)