### PR TITLE
Add duplicate serial number warning on save

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,6 +147,9 @@ const elements = {
   addEquipmentName: document.querySelector("#new-equipment-name"),
   addEquipmentModel: document.querySelector("#new-equipment-model"),
   addEquipmentSerial: document.querySelector("#new-equipment-serial"),
+  addEquipmentSerialWarning: document.querySelector(
+    "#new-equipment-serial-warning"
+  ),
   addEquipmentPurchaseDate: document.querySelector(
     "#new-equipment-purchase-date"
   ),
@@ -181,6 +184,9 @@ const elements = {
   ),
   editEquipmentModel: document.querySelector("#edit-equipment-model"),
   editEquipmentSerial: document.querySelector("#edit-equipment-serial"),
+  editEquipmentSerialWarning: document.querySelector(
+    "#edit-equipment-serial-warning"
+  ),
   editEquipmentPurchaseDate: document.querySelector(
     "#edit-equipment-purchase-date"
   ),
@@ -915,8 +921,9 @@ function handleAddEquipment(event) {
     lastCalibrationDate,
   });
 
+  const newItemId = crypto.randomUUID();
   state.equipment.push({
-    id: crypto.randomUUID(),
+    id: newItemId,
     name,
     model,
     serialNumber,
@@ -928,6 +935,11 @@ function handleAddEquipment(event) {
   });
 
   logHistory(`${name} added to ${location} with status ${status}.`);
+  toggleSerialWarning(
+    elements.addEquipmentSerialWarning,
+    serialNumber,
+    newItemId
+  );
   elements.addEquipmentName.value = "";
   elements.addEquipmentModel.value = "";
   elements.addEquipmentSerial.value = "";
@@ -999,6 +1011,7 @@ function syncEditForm() {
   elements.editEquipmentLastCalibration.value = item.lastCalibrationDate ?? "";
   syncEditCalibrationInputs();
   clearEditNameError();
+  clearSerialWarning(elements.editEquipmentSerialWarning);
 }
 
 function resetEditForm() {
@@ -1033,6 +1046,7 @@ function resetEditForm() {
   elements.editEquipmentLastCalibration.value = "";
   syncEditCalibrationInputs();
   clearEditNameError();
+  clearSerialWarning(elements.editEquipmentSerialWarning);
 }
 
 function syncEditCalibrationInputs() {
@@ -1101,6 +1115,36 @@ function clearEditNameError() {
 function showEditNameError() {
   if (elements.editEquipmentNameError) {
     elements.editEquipmentNameError.classList.remove("is-hidden");
+  }
+}
+
+function findSerialNumberMatch(serialNumber, excludeId) {
+  const normalized = serialNumber.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return state.equipment.find((item) => {
+    if (excludeId && item.id === excludeId) {
+      return false;
+    }
+    const itemSerial = item.serialNumber?.trim().toLowerCase() ?? "";
+    return itemSerial && itemSerial === normalized;
+  });
+}
+
+function toggleSerialWarning(warningElement, serialNumber, excludeId) {
+  if (!warningElement) {
+    return;
+  }
+  const hasMatch = Boolean(
+    findSerialNumberMatch(serialNumber, excludeId)
+  );
+  warningElement.classList.toggle("is-hidden", !hasMatch);
+}
+
+function clearSerialWarning(warningElement) {
+  if (warningElement) {
+    warningElement.classList.add("is-hidden");
   }
 }
 
@@ -1190,6 +1234,11 @@ function handleEditEquipmentSubmit(event) {
     );
   }
 
+  toggleSerialWarning(
+    elements.editEquipmentSerialWarning,
+    serialNumber,
+    item.id
+  );
   saveState();
   refreshUI();
 }
@@ -1325,6 +1374,12 @@ if (elements.addEquipmentCalibrationInterval) {
   );
 }
 
+if (elements.addEquipmentSerial) {
+  elements.addEquipmentSerial.addEventListener("input", () => {
+    clearSerialWarning(elements.addEquipmentSerialWarning);
+  });
+}
+
 if (elements.editEquipmentForm) {
   elements.editEquipmentForm.addEventListener(
     "submit",
@@ -1348,6 +1403,12 @@ if (elements.editEquipmentCalibrationInterval) {
     "change",
     syncEditCalibrationInputs
   );
+}
+
+if (elements.editEquipmentSerial) {
+  elements.editEquipmentSerial.addEventListener("input", () => {
+    clearSerialWarning(elements.editEquipmentSerialWarning);
+  });
 }
 
 if (elements.editEquipmentName) {

--- a/index.html
+++ b/index.html
@@ -159,6 +159,12 @@
               <label>
                 Serial number
                 <input id="new-equipment-serial" type="text" />
+                <span
+                  id="new-equipment-serial-warning"
+                  class="field-warning is-hidden"
+                >
+                  Another item already has this serial number.
+                </span>
               </label>
               <label>
                 Purchase date
@@ -228,6 +234,12 @@
               <label>
                 Serial number
                 <input id="edit-equipment-serial" type="text" />
+                <span
+                  id="edit-equipment-serial-warning"
+                  class="field-warning is-hidden"
+                >
+                  Another item already has this serial number.
+                </span>
               </label>
               <label>
                 Purchase date

--- a/styles.css
+++ b/styles.css
@@ -329,6 +329,11 @@ tr:last-child td {
   color: #b42318;
 }
 
+.field-warning {
+  font-size: 12px;
+  color: #b4690e;
+}
+
 button {
   border: none;
   border-radius: 10px;


### PR DESCRIPTION
### Motivation
- Surface a non-blocking warning when a saved item uses a serial number already present on another item, to make users aware of duplicate internal tags without preventing saves.

### Description
- Added warning elements to the add/edit forms in `index.html` with the text "Another item already has this serial number.".
- Introduced `.field-warning` styling in `styles.css` to make the message visible and distinct from errors.
- Implemented `findSerialNumberMatch`, `toggleSerialWarning`, and `clearSerialWarning` in `app.js` to detect case-insensitive serial duplicates (excluding the item being edited) and show/hide the warning on save and input events.
- Wired up element references and event listeners so warnings are shown after saving a new or edited item and cleared while the user edits the serial input; saves remain allowed (no blocking).

### Testing
- Started a local static server with `python -m http.server 8000`, which served the app successfully.  
- Attempted automated browser verification with Playwright to add an item using a duplicate serial and wait for the warning, but the Playwright runs timed out and did not produce a screenshot.  
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a176f9a483339eb61042a4853988)