### PR TITLE
Add duplicate equipment name warning in Edit Equipment panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,12 @@
                   >
                     Equipment name is required.
                   </span>
+                  <span
+                    id="edit-equipment-name-warning"
+                    class="field-warning is-hidden"
+                  >
+                    Another item already uses this name.
+                  </span>
                 </label>
                 <label>
                   Model


### PR DESCRIPTION
### Motivation
- Provide a non-blocking visual warning when an edited equipment name duplicates another item, using `equipment.name` as the comparison field and matching existing duplicate-serial UX.
- Normalize names before comparing by converting to string, trimming whitespace, and comparing case-insensitively.
- Ensure the warning is visible while typing and during save/final validation, but does not prevent saving.

### Description
- Added a new warning element in the Edit Equipment form (`#edit-equipment-name-warning`) that uses the same `field-warning` styling as the serial warning. 
- Implemented `normalizeEquipmentName`, `findDuplicateName(name, equipmentList, excludeEquipmentId)` and `toggleNameWarning`/`clearNameWarning` helpers; `findDuplicateName` returns the first matching equipment item or `null` and excludes the currently edited item by id. 
- Integrated the duplicate-name check into `syncEditForm`, the edit name input handler (so the warning updates while typing), and `handleEditEquipmentSubmit` (final validation pass); the warning message format is: `Another item already uses this name: <name> (<model>, <serialNumber or 'no serial'>, <location>)`.
- The behavior mirrors the existing duplicate-serial flow and does not block save; the warning hides automatically when the name becomes unique.

### Testing
- Started a local static server with `python -m http.server 8000` and ran a Playwright script that loads `/index.html`, triggers the Edit panel warning state, and captures a screenshot at `artifacts/edit-equipment-name-warning.png`, and the script completed successfully. 
- Existing duplicate-serial logic was left intact and exercised by the same manual/automated browser run above which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a7c005288333863264f9d141e52e)