### PR TITLE
Add Moves tab with filters, normalized history, and admin deletions

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,30 +19,51 @@
         </div>
       </header>
 
-      <nav class="tabs" role="tablist" aria-label="Equipment tracker sections">
-        <button
-          class="tab-button"
-          type="button"
-          id="tab-button-operations"
-          role="tab"
-          aria-selected="true"
-          aria-controls="tab-operations"
-          data-tab="operations"
+      <div class="tab-bar">
+        <nav
+          class="tabs"
+          role="tablist"
+          aria-label="Equipment tracker sections"
         >
-          Operations
-        </button>
-        <button
-          class="tab-button"
-          type="button"
-          id="tab-button-admin"
-          role="tab"
-          aria-selected="false"
-          aria-controls="tab-admin"
-          data-tab="admin"
-        >
-          Admin
-        </button>
-      </nav>
+          <button
+            class="tab-button"
+            type="button"
+            id="tab-button-operations"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tab-operations"
+            data-tab="operations"
+          >
+            Operations
+          </button>
+          <button
+            class="tab-button"
+            type="button"
+            id="tab-button-moves"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tab-moves"
+            data-tab="moves"
+          >
+            Moves
+          </button>
+          <button
+            class="tab-button"
+            type="button"
+            id="tab-button-admin"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tab-admin"
+            data-tab="admin"
+          >
+            Admin
+          </button>
+        </nav>
+        <label class="admin-toggle" for="admin-mode-toggle">
+          <span>Admin mode</span>
+          <input id="admin-mode-toggle" type="checkbox" />
+        </label>
+      </div>
 
       <main>
         <div id="operations-view">
@@ -200,6 +221,48 @@
                 </div>
               </section>
             </div>
+          </section>
+        </div>
+
+        <div id="moves-view" hidden>
+          <section
+            id="tab-moves"
+            class="tab-panel"
+            role="tabpanel"
+            aria-labelledby="tab-button-moves"
+          >
+            <section class="card">
+              <div class="card-header">
+                <div>
+                  <h2>Moves log</h2>
+                  <p>Review every recorded move, calibration, and update.</p>
+                </div>
+                <div class="filters">
+                  <div class="filter">
+                    <label for="moves-equipment-filter">Equipment</label>
+                    <select id="moves-equipment-filter"></select>
+                  </div>
+                  <div class="filter">
+                    <label for="moves-type-filter">Type</label>
+                    <select id="moves-type-filter"></select>
+                  </div>
+                </div>
+              </div>
+              <div class="search">
+                <input
+                  id="moves-search"
+                  type="search"
+                  placeholder="Search moves and notes..."
+                  autocomplete="off"
+                />
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead id="moves-table-header"></thead>
+                  <tbody id="moves-table-body"></tbody>
+                </table>
+              </div>
+            </section>
           </section>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,15 @@ h1 {
   box-shadow: 0 12px 30px rgba(35, 42, 66, 0.08);
 }
 
+.tab-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
 .tabs {
   display: inline-flex;
   gap: 8px;
@@ -73,7 +82,6 @@ h1 {
   border-radius: 999px;
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.7);
-  margin-bottom: 24px;
 }
 
 .tab-button {
@@ -96,6 +104,25 @@ h1 {
 .tab-button:focus-visible {
   outline: 2px solid rgba(75, 110, 245, 0.4);
   outline-offset: 2px;
+}
+
+.admin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.admin-toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
 }
 
 .tab-panel {
@@ -387,6 +414,19 @@ button {
 
 button:hover {
   background: var(--accent-dark);
+}
+
+.icon-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--accent-dark);
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+}
+
+.icon-button:hover {
+  background: rgba(49, 73, 198, 0.08);
 }
 
 .history {


### PR DESCRIPTION
### Motivation
- Provide a dedicated, top-level Moves view that shows a complete chronological log of all move/calibration/detail entries so operators can review history independent of the main equipment table. 
- Allow filtering of the moves log by equipment, type and free-text, while keeping the main equipment table unaffected. 
- Permit removal of log entries only when Admin mode is enabled and persisted, while keeping Moves readable for non-admin users.

### Description
- Added a new Moves tab and view (`#moves-view`, `#tab-moves`) and an Admin mode toggle in the tab bar in `index.html`, and wired DOM nodes in `app.js` to the new controls. 
- Implemented styles for the tab bar, admin toggle and row action button in `styles.css` and added an `icon-button` style for delete controls. 
- Normalized and migrated history entries by adding `normalizeHistoryEntry`/`normalizeHistoryEntries` (stable `id`, inferred `type`, equipment metadata, from/to/status fields) and changed `logHistory` to push structured entries to `state.history` in `app.js`. 
- Rendered the moves table (`moves-table-header`/`moves-table-body`) with columns `Timestamp`, `Equipment`, `From location`, `To location`, `Status change`, `Notes`, `Type`, and an `Actions` column when admin mode is ON, and added filters: `moves-equipment-filter`, `moves-type-filter`, and `moves-search`. 
- Added Admin mode persistence via `equipmentTrackerAdminMode` (localStorage) and `setAdminMode` logic which hides/shows the Admin tab and toggles delete availability, and ensured `equipmentTrackerActiveTab` respects available tabs. 
- Added delete handling (`handleDeleteHistoryEntry`) with a confirmation prompt and persisted deletion to `localStorage`, and guarded delete controls so they only appear and act when admin mode is enabled. 

### Testing
- Launched a local static server with `python -m http.server` to serve the app and verify files load, which started successfully. 
- Attempted an automated Playwright script to open the page and capture a screenshot of the Moves view, but the Playwright run timed out and did not complete. 
- No unit tests were added; changes were exercised via the running app and manual code inspection of the rendered DOM and event wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ac3fe8288333996e57f6bf1d7153)