### PR TITLE
Robust state migration/normalization and tab fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,17 @@
           <button
             class="tab-button"
             type="button"
+            id="tab-button-moves"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tab-moves"
+            data-tab="moves"
+          >
+            Moves
+          </button>
+          <button
+            class="tab-button"
+            type="button"
             id="tab-button-admin"
             role="tab"
             aria-selected="false"


### PR DESCRIPTION
### Motivation
- Ensure legacy or malformed localStorage data under `equipmentTrackerState` continues to load without crashing and that the UI populates equipment and moves correctly.
- Use a single canonical schema with `equipment` and `moves` arrays so downstream rendering and dropdowns work reliably.
- Make tab handling and persistence resilient to unknown/legacy values and add the missing Moves tab so sections are reachable.

### Description
- Added migration helpers: `migrateStoredState`, `findArrayFallback`, and `normalizeState` to load legacy keys (`items`, `history`, `log`, etc.) and report migrated keys via `console.warn` while preserving user data.
- Canonicalized storage shape to use `equipment` (array) and `moves` (array) and updated all rendering/CRUD to read/write `state.moves` instead of legacy `history`.
- Strengthened `normalizeEquipment` and `normalizeCalibrationFields` to ensure every equipment entry has required fields (`id`, `name`, `model`, `serialNumber`, `location`, `status`, `calibrationRequired`, `calibrationIntervalMonths`, `lastCalibrationDate`, `purchaseDate`, `lastMoved`) with sensible defaults and id generation when missing.
- Implemented tab normalization (`normalizeTabName`) so `equipmentTrackerActiveTab` is interpreted in lowercase and unknown values default to `operations`, and setActiveTab now supports `moves` view independent of equipment data.
- Added a `Moves` tab button to `index.html` and adjusted tab initialization/keyboard handling to work regardless of stored equipment presence.
- Preserved seeding behavior by returning the seeded demo state only when there is no stored state or parsing fails, and avoided wiping user data during migration.

### Testing
- Started a local HTTP server with `python -m http.server 8000` and ran a Playwright smoke script that navigated to `http://127.0.0.1:8000/index.html` and captured a screenshot; the script completed successfully and produced `artifacts/equipment-tabs.png` (smoke test passed).
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b18aaff48333b72010199d98b444)