### PR TITLE
Add Admin equipment import (CSV) with preview, validation, and local import

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,77 @@
                     </button>
                   </div>
                 </form>
+
+                <div class="panel import-panel">
+                  <h3>Import equipment</h3>
+                  <p class="panel-hint">
+                    Upload a CSV to bulk add equipment. Existing items are never
+                    removed.
+                  </p>
+                  <div class="panel-actions">
+                    <button type="button" id="import-template-button">
+                      Download CSV template
+                    </button>
+                  </div>
+                  <label>
+                    CSV file
+                    <input
+                      id="import-file-input"
+                      type="file"
+                      accept=".csv"
+                    />
+                  </label>
+                  <label>
+                    On duplicate serial
+                    <select id="import-duplicate-behavior">
+                      <option value="skip" selected>Skip</option>
+                      <option value="import">Import anyway</option>
+                    </select>
+                  </label>
+                  <div class="import-summary" id="import-summary" aria-live="polite">
+                    <div>
+                      <span class="import-label">Rows detected</span>
+                      <strong id="import-total-count">0</strong>
+                    </div>
+                    <div>
+                      <span class="import-label">Valid</span>
+                      <strong id="import-valid-count">0</strong>
+                    </div>
+                    <div>
+                      <span class="import-label">Invalid</span>
+                      <strong id="import-invalid-count">0</strong>
+                    </div>
+                  </div>
+                  <div class="import-preview">
+                    <p id="import-empty-state" class="import-empty">
+                      Select a CSV file to preview the import.
+                    </p>
+                    <div class="import-preview-table table-wrapper is-hidden">
+                      <table>
+                        <thead id="import-preview-header"></thead>
+                        <tbody id="import-preview-body"></tbody>
+                      </table>
+                    </div>
+                  </div>
+                  <div class="import-warnings">
+                    <h4>Warnings</h4>
+                    <ul id="import-warnings" class="import-warning-list">
+                      <li class="import-empty">No warnings yet.</li>
+                    </ul>
+                  </div>
+                  <div class="panel-actions">
+                    <button type="button" id="import-submit" disabled>
+                      Import
+                    </button>
+                    <button
+                      type="button"
+                      class="button-secondary"
+                      id="import-clear"
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
               </div>
             </section>
           </section>

--- a/styles.css
+++ b/styles.css
@@ -355,6 +355,12 @@ tr:last-child td {
   font-size: 16px;
 }
 
+.panel-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .panel label {
   display: grid;
   gap: 6px;
@@ -366,6 +372,74 @@ tr:last-child td {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.import-panel {
+  grid-column: 1 / -1;
+}
+
+.import-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f4f6fd;
+  border: 1px solid var(--border);
+}
+
+.import-label {
+  display: block;
+  font-size: 11px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.import-preview {
+  display: grid;
+  gap: 12px;
+}
+
+.import-preview-table {
+  max-height: 240px;
+}
+
+.import-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.import-warnings {
+  display: grid;
+  gap: 8px;
+}
+
+.import-warnings h4 {
+  margin: 0;
+  font-size: 13px;
+}
+
+.import-warning-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.import-preview-table table {
+  font-size: 12px;
+}
+
+.import-preview-table th,
+.import-preview-table td {
+  padding: 8px 10px;
+}
+
+.import-row-invalid {
+  background: rgba(180, 105, 14, 0.08);
 }
 
 .button-secondary {


### PR DESCRIPTION
### Motivation
- Provide a frontend-only, CSV-first workflow in the Admin tab to bulk-add equipment without any backend, while preserving existing data and integrating with the app's schema and UI.
- Give admins a safe preview and validation step before persisting new equipment into localStorage and the app history log.

### Description
- Add a new "Import equipment" panel in the Admin view with template download, CSV file input, duplicate-behaviour selector, preview table, warnings area, and Import/Clear actions (markup in `index.html`).
- Add styles for the import panel, summary, preview table and warnings (`styles.css`).
- Implement in-browser CSV parsing, flexible date parsing (YYYY-MM-DD and DD/MM/YYYY), trimming/normalization and per-row validation in `app.js`, including defaulting unknown locations/status and calibration field normalization.
- Implement duplicate detection (case-insensitive serial match), a dropdown to choose duplicate behaviour (Skip / Import anyway), stable id generation for imports, preview rendering (rows detected, valid/invalid counts, first ~20 rows) and import flow that appends items to `state.equipment`, persists via `localStorage`, refreshes UI, and logs a history entry.

### Testing
- Started a static server with `python -m http.server 8000` to serve the frontend and the server started successfully. 
- Ran a Playwright script to open the app, enable Admin mode and capture a screenshot, but the Playwright run failed with a `TargetClosedError` (browser crash) in this environment so automated UI validation did not complete. 
- No unit tests exist for this project and no other automated tests were run; manual inspection of files and a commit were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981af97c44c833383e9013f5bab510f)