### PR TITLE
Fix import template download handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -2373,7 +2373,7 @@ function handleAddEquipment(event) {
   syncCalibrationInputs();
 }
 
-function downloadEquipmentTemplate() {
+function downloadImportTemplateCSV() {
   const template = buildEquipmentImportTemplate();
   const blob = new Blob([template], { type: "text/csv" });
   const url = URL.createObjectURL(blob);
@@ -3102,12 +3102,15 @@ if (elements.addEquipmentSerial) {
   elements.addEquipmentSerial.addEventListener("change", handleAddSerialInput);
 }
 
-if (elements.importTemplateButton) {
-  elements.importTemplateButton.addEventListener(
-    "click",
-    downloadEquipmentTemplate
-  );
-}
+document.addEventListener("click", (event) => {
+  const button = event.target.closest("#import-template-button");
+  if (!button) {
+    return;
+  }
+  event.preventDefault();
+  console.log("Downloading import template...");
+  downloadImportTemplateCSV();
+});
 
 if (elements.importFileInput) {
   elements.importFileInput.addEventListener("change", handleImportFileChange);


### PR DESCRIPTION
### Motivation
- The existing `#import-template-button` click did not reliably trigger after the admin/import panel was re-rendered, so the "Download CSV template" button appeared to do nothing.
- Use event delegation so the handler still works if the panel DOM is recreated, and expose a dedicated download helper to centralise download logic.

### Description
- Replaced the direct element listener with a document-level delegated click handler that looks for `#import-template-button` and calls `downloadImportTemplateCSV()` on clicks. 
- Added `downloadImportTemplateCSV()` which generates the CSV (via the existing `buildEquipmentImportTemplate()`), creates a `Blob`, and triggers download using a temporary `<a>` with `download` set to `equipment-import-template.csv`.
- Added a temporary debug log `console.log("Downloading import template...")` in the click path so the download action is observable in the console.
- Changes applied to `app.js` (replaced the old `downloadEquipmentTemplate` usage and the previous element binding).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f7da63208333ba00b50efea9cf56)