### PR TITLE
Add subscription tracking for equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,16 @@
                 <strong id="stat-overdue">0</strong>
               </div>
               <div>
-                <span class="stat-label">Due soon</span>
+                <span class="stat-label">Due soon calibration</span>
                 <strong id="stat-due-soon">0</strong>
+              </div>
+              <div>
+                <span class="stat-label">Overdue subscription</span>
+                <strong id="stat-overdue-subscription">0</strong>
+              </div>
+              <div>
+                <span class="stat-label">Due soon subscription</span>
+                <strong id="stat-due-soon-subscription">0</strong>
               </div>
             </div>
 
@@ -112,6 +120,10 @@
                       <label for="calibration-filter">Calibration</label>
                       <select id="calibration-filter"></select>
                     </div>
+                    <div class="filter">
+                      <label for="subscription-filter">Subscription</label>
+                      <select id="subscription-filter"></select>
+                    </div>
                   </div>
                 </div>
                 <div class="search">
@@ -132,6 +144,7 @@
                         <th>Status</th>
                         <th>Location</th>
                         <th>Calibration</th>
+                        <th>Subscription</th>
                         <th>Last moved</th>
                       </tr>
                     </thead>
@@ -154,7 +167,10 @@
 
               <section class="card">
                 <h2>Console</h2>
-                <p>Use the console to log moves or record calibration.</p>
+                <p>
+                  Use the console to log moves, record calibration, or renew
+                  subscriptions.
+                </p>
 
                 <div class="console">
                   <form id="move-form" class="panel">
@@ -208,6 +224,33 @@
                     </label>
                     <button type="submit">Save calibration</button>
                   </form>
+
+                  <form id="subscription-form" class="panel">
+                    <h3>Record subscription</h3>
+                    <label>
+                      Equipment
+                      <select id="subscription-equipment"></select>
+                    </label>
+                    <label>
+                      Renewal date
+                      <input id="subscription-date" type="date" />
+                    </label>
+                    <label>
+                      Interval months (optional override)
+                      <input
+                        id="subscription-interval"
+                        type="number"
+                        min="1"
+                        step="1"
+                        placeholder="e.g. 18"
+                      />
+                    </label>
+                    <label class="checkbox-field">
+                      Subscription required
+                      <input id="subscription-required" type="checkbox" />
+                    </label>
+                    <button type="submit">Save subscription</button>
+                  </form>
                 </div>
 
                 <div class="history">
@@ -235,7 +278,10 @@
               <div class="card-header">
                 <div>
                   <h2>Moves log</h2>
-                  <p>Review every recorded move, calibration, and update.</p>
+                  <p>
+                    Review every recorded move, calibration, subscription, and
+                    update.
+                  </p>
                 </div>
                 <div class="filters">
                   <div class="filter">


### PR DESCRIPTION
### Motivation
- Some equipment requires periodic/annual subscriptions and the tracker needs to store renewal info, surface due/overdue warnings, and let operators record renewals via the console.

### Description
- Add per-item subscription fields: `subscriptionRequired`, `subscriptionRenewalDate`, and `subscriptionIntervalMonths`, and backfill defaults in seeded state and normalization (`normalizeSubscriptionFields`).
- Implement computed subscription status via `getSubscriptionInfo` with the 30-day "Due soon" threshold and integrate it into UI rendering (table badge), stats counters, and import handling (`normalizeSubscriptionFields` used for imports and `add` flows).
- Add subscription UI: new stats cards (`#stat-overdue-subscription`, `#stat-due-soon-subscription`), filter control (`#subscription-filter`), table column `Subscription`, and a console form (`#subscription-form`) to record/renew subscriptions.
- Logging and moves: introduce history type `subscription_updated`, include `subscription_updated` entries in `moveTypeOptions`, and include subscription-aware filtering in the moves log and general filtering logic.

### Testing
- Started a local static server with `python -m http.server 8000` to host the app (succeeded). 
- Ran a Playwright screenshot run: Chromium launch crashed (segfault); reran with Firefox which succeeded and produced a screenshot at `artifacts/subscription-ui.png` verifying the new UI was rendered. 
- No unit tests were present or run beyond the browser smoke test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f9d4189483339ebda4cbac4193b3)