### PR TITLE
Move subscription management into Admin; remove interval field and operations panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,7 +88,6 @@ function buildDefaultState() {
         calibrationIntervalMonths: 12,
         lastCalibrationDate: getSeedDate({ months: -3 }),
         subscriptionRequired: false,
-        subscriptionIntervalMonths: 12,
         subscriptionRenewalDate: "",
       },
       {
@@ -104,7 +103,6 @@ function buildDefaultState() {
         calibrationIntervalMonths: 12,
         lastCalibrationDate: getSeedDate({ months: -6 }),
         subscriptionRequired: false,
-        subscriptionIntervalMonths: 12,
         subscriptionRenewalDate: "",
       },
       {
@@ -120,7 +118,6 @@ function buildDefaultState() {
         calibrationIntervalMonths: 12,
         lastCalibrationDate: getSeedDate({ months: -14 }),
         subscriptionRequired: false,
-        subscriptionIntervalMonths: 12,
         subscriptionRenewalDate: "",
       },
       {
@@ -136,7 +133,6 @@ function buildDefaultState() {
         calibrationIntervalMonths: 12,
         lastCalibrationDate: getSeedDate({ months: -10, days: -5 }),
         subscriptionRequired: false,
-        subscriptionIntervalMonths: 12,
         subscriptionRenewalDate: "",
       },
     ],
@@ -193,11 +189,6 @@ const elements = {
   calibrationDate: document.querySelector("#calibration-date"),
   calibrationInterval: document.querySelector("#calibration-interval"),
   calibrationRequired: document.querySelector("#calibration-required"),
-  subscriptionForm: document.querySelector("#subscription-form"),
-  subscriptionEquipment: document.querySelector("#subscription-equipment"),
-  subscriptionDate: document.querySelector("#subscription-date"),
-  subscriptionInterval: document.querySelector("#subscription-interval"),
-  subscriptionRequired: document.querySelector("#subscription-required"),
   addEquipmentForm: document.querySelector("#add-equipment-form"),
   addEquipmentName: document.querySelector("#new-equipment-name"),
   addEquipmentModel: document.querySelector("#new-equipment-model"),
@@ -230,6 +221,15 @@ const elements = {
   ),
   addEquipmentLastCalibrationField: document.querySelector(
     "#new-equipment-last-calibration-field"
+  ),
+  addEquipmentSubscriptionRequired: document.querySelector(
+    "#new-equipment-subscription-required"
+  ),
+  addEquipmentSubscriptionDate: document.querySelector(
+    "#new-equipment-subscription-date"
+  ),
+  addEquipmentSubscriptionDateField: document.querySelector(
+    "#new-equipment-subscription-date-field"
   ),
   editEquipmentForm: document.querySelector("#edit-equipment-form"),
   editEquipmentSelect: document.querySelector("#edit-equipment-select"),
@@ -270,6 +270,15 @@ const elements = {
   ),
   editEquipmentLastCalibrationField: document.querySelector(
     "#edit-equipment-last-calibration-field"
+  ),
+  editEquipmentSubscriptionRequired: document.querySelector(
+    "#edit-equipment-subscription-required"
+  ),
+  editEquipmentSubscriptionDate: document.querySelector(
+    "#edit-equipment-subscription-date"
+  ),
+  editEquipmentSubscriptionDateField: document.querySelector(
+    "#edit-equipment-subscription-date-field"
   ),
   editEquipmentCancel: document.querySelector("#edit-equipment-cancel"),
   historyList: document.querySelector("#history-list"),
@@ -1027,7 +1036,6 @@ function renderEquipmentOptions() {
   [
     elements.moveEquipment,
     elements.calibrationEquipment,
-    elements.subscriptionEquipment,
     elements.editEquipmentSelect,
   ].forEach((selectEl) => {
     populateEquipmentSelect(selectEl, equipmentList, selectEl?.value);
@@ -1352,68 +1360,69 @@ function buildEquipmentImportTemplate() {
 
 function normalizeEquipment(item = {}) {
   const safeItem = item && typeof item === "object" ? item : {};
+  const { subscriptionIntervalMonths, ...normalizedBase } = safeItem;
   const name =
-    typeof safeItem.name === "string"
-      ? safeItem.name
-      : safeItem.name != null
-        ? String(safeItem.name)
+    typeof normalizedBase.name === "string"
+      ? normalizedBase.name
+      : normalizedBase.name != null
+        ? String(normalizedBase.name)
         : "";
   const location =
-    typeof safeItem.location === "string"
-      ? safeItem.location
-      : safeItem.location != null
-        ? String(safeItem.location)
+    typeof normalizedBase.location === "string"
+      ? normalizedBase.location
+      : normalizedBase.location != null
+        ? String(normalizedBase.location)
         : "";
   const status =
-    typeof safeItem.status === "string"
-      ? safeItem.status
-      : safeItem.status != null
-        ? String(safeItem.status)
+    typeof normalizedBase.status === "string"
+      ? normalizedBase.status
+      : normalizedBase.status != null
+        ? String(normalizedBase.status)
         : "";
   const model =
-    typeof safeItem.model === "string"
-      ? safeItem.model
-      : safeItem.model != null
-        ? String(safeItem.model)
+    typeof normalizedBase.model === "string"
+      ? normalizedBase.model
+      : normalizedBase.model != null
+        ? String(normalizedBase.model)
         : "";
   const serialNumber =
-    typeof safeItem.serialNumber === "string"
-      ? safeItem.serialNumber
-      : safeItem.serialNumber != null
-        ? String(safeItem.serialNumber)
+    typeof normalizedBase.serialNumber === "string"
+      ? normalizedBase.serialNumber
+      : normalizedBase.serialNumber != null
+        ? String(normalizedBase.serialNumber)
         : "";
   const purchaseDate =
-    typeof safeItem.purchaseDate === "string"
-      ? safeItem.purchaseDate
-      : safeItem.purchaseDate != null
-        ? String(safeItem.purchaseDate)
+    typeof normalizedBase.purchaseDate === "string"
+      ? normalizedBase.purchaseDate
+      : normalizedBase.purchaseDate != null
+        ? String(normalizedBase.purchaseDate)
         : "";
   const lastCalibrationDate =
-    typeof safeItem.lastCalibrationDate === "string"
-      ? safeItem.lastCalibrationDate
-      : safeItem.lastCalibrationDate != null
-        ? String(safeItem.lastCalibrationDate)
+    typeof normalizedBase.lastCalibrationDate === "string"
+      ? normalizedBase.lastCalibrationDate
+      : normalizedBase.lastCalibrationDate != null
+        ? String(normalizedBase.lastCalibrationDate)
         : "";
   const subscriptionRenewalDate =
-    typeof safeItem.subscriptionRenewalDate === "string"
-      ? safeItem.subscriptionRenewalDate
-      : safeItem.subscriptionRenewalDate != null
-        ? String(safeItem.subscriptionRenewalDate)
+    typeof normalizedBase.subscriptionRenewalDate === "string"
+      ? normalizedBase.subscriptionRenewalDate
+      : normalizedBase.subscriptionRenewalDate != null
+        ? String(normalizedBase.subscriptionRenewalDate)
         : "";
   const calibrationRequired =
-    typeof safeItem.calibrationRequired === "boolean"
-      ? safeItem.calibrationRequired
+    typeof normalizedBase.calibrationRequired === "boolean"
+      ? normalizedBase.calibrationRequired
       : false;
   const subscriptionRequired =
-    typeof safeItem.subscriptionRequired === "boolean"
-      ? safeItem.subscriptionRequired
+    typeof normalizedBase.subscriptionRequired === "boolean"
+      ? normalizedBase.subscriptionRequired
       : false;
 
   return {
-    ...safeItem,
+    ...normalizedBase,
     id:
-      typeof safeItem.id === "string" && safeItem.id.trim()
-        ? safeItem.id
+      typeof normalizedBase.id === "string" && normalizedBase.id.trim()
+        ? normalizedBase.id
         : crypto.randomUUID(),
     name: name?.trim() ? name : "Unnamed",
     location: location?.trim() ? location : physicalLocations[0],
@@ -1428,10 +1437,6 @@ function normalizeEquipment(item = {}) {
         : Number(safeItem.calibrationIntervalMonths) || 12,
     lastCalibrationDate,
     subscriptionRequired,
-    subscriptionIntervalMonths:
-      typeof safeItem.subscriptionIntervalMonths === "number"
-        ? safeItem.subscriptionIntervalMonths
-        : Number(safeItem.subscriptionIntervalMonths) || 12,
     subscriptionRenewalDate,
     lastMoved:
       typeof safeItem.lastMoved === "string"
@@ -1458,18 +1463,12 @@ function normalizeCalibrationFields(item) {
 
 function normalizeSubscriptionFields(item) {
   const subscriptionRequired = Boolean(item.subscriptionRequired);
-  const intervalValue = Number(item.subscriptionIntervalMonths);
-  const subscriptionIntervalMonths =
-    Number.isFinite(intervalValue) && intervalValue > 0
-      ? intervalValue
-      : 12;
   const renewalDate = parseSubscriptionDate(item.subscriptionRenewalDate)
     ? item.subscriptionRenewalDate
     : "";
 
   return {
     subscriptionRequired,
-    subscriptionIntervalMonths,
     subscriptionRenewalDate: renewalDate,
   };
 }
@@ -1899,9 +1898,16 @@ function renderTable() {
             : subscriptionInfo.status === "Unknown"
               ? "Renewal date needed"
               : "Subscription not required";
-          const subscriptionCell = `<span class="tag tag--status" title="${escapeHTML(
+          const subscriptionDateLabel = subscriptionInfo.renewalDate
+            ? formatDate(subscriptionInfo.renewalDate)
+            : "";
+          const subscriptionCell = `<div class="status-with-meta"><span class="tag tag--status" title="${escapeHTML(
             subscriptionMeta
-          )}">${escapeHTML(subscriptionInfo.status)}</span>`;
+          )}">${escapeHTML(subscriptionInfo.status)}</span>${
+            subscriptionDateLabel
+              ? `<small class="status-meta">${escapeHTML(subscriptionDateLabel)}</small>`
+              : ""
+          }</div>`;
           const modelLabel = item.model?.trim() ? item.model : "—";
           const serialLabel = item.serialNumber?.trim()
             ? item.serialNumber
@@ -2214,7 +2220,7 @@ function refreshUI() {
   renderLocationSummary();
   renderMovesView();
   syncCalibrationForm();
-  syncSubscriptionForm();
+  syncAddSubscriptionInputs({ clearWhenDisabled: false });
   syncEditForm();
 }
 
@@ -2362,6 +2368,18 @@ function logHistory(entry) {
   state.moves.unshift(historyEntry);
 }
 
+function buildSubscriptionNotes({
+  subscriptionRequired,
+  subscriptionRenewalDate,
+}) {
+  const renewalLabel = subscriptionRenewalDate
+    ? subscriptionRenewalDate
+    : "unknown";
+  return `Subscription required: ${
+    subscriptionRequired ? "true" : "false"
+  }, renewal date: ${renewalLabel}.`;
+}
+
 function handleMoveSubmit(event) {
   event.preventDefault();
   if (
@@ -2438,26 +2456,6 @@ function syncCalibrationForm() {
   }
 }
 
-function syncSubscriptionForm() {
-  if (
-    !elements.subscriptionEquipment ||
-    !elements.subscriptionDate ||
-    !elements.subscriptionRequired
-  ) {
-    return;
-  }
-  const equipmentId = elements.subscriptionEquipment.value;
-  const item = state.equipment.find((entry) => entry.id === equipmentId);
-  if (!item) {
-    return;
-  }
-  elements.subscriptionRequired.checked = Boolean(item.subscriptionRequired);
-  elements.subscriptionDate.value = item.subscriptionRenewalDate ?? "";
-  if (!elements.subscriptionDate.value) {
-    elements.subscriptionDate.value = formatDate(new Date());
-  }
-}
-
 function handleCalibrationSubmit(event) {
   event.preventDefault();
   if (
@@ -2505,59 +2503,6 @@ function handleCalibrationSubmit(event) {
   refreshUI();
 }
 
-function handleSubscriptionSubmit(event) {
-  event.preventDefault();
-  if (
-    !elements.subscriptionEquipment ||
-    !elements.subscriptionDate ||
-    !elements.subscriptionRequired
-  ) {
-    return;
-  }
-
-  const equipmentId = elements.subscriptionEquipment.value;
-  const item = state.equipment.find((entry) => entry.id === equipmentId);
-  if (!item) {
-    return;
-  }
-
-  const subscriptionRequired = elements.subscriptionRequired.checked;
-  const renewalDate = elements.subscriptionDate.value;
-  item.subscriptionRequired = subscriptionRequired;
-  item.subscriptionRenewalDate = subscriptionRequired ? renewalDate : "";
-
-  const intervalValue = elements.subscriptionInterval?.value ?? "";
-  if (String(intervalValue).trim()) {
-    const parsedInterval = Number(intervalValue);
-    if (Number.isFinite(parsedInterval) && parsedInterval > 0) {
-      item.subscriptionIntervalMonths = parsedInterval;
-    }
-  }
-
-  item.lastMoved = formatTimestamp();
-  const notes = `Subscription updated: renewalDate=${
-    item.subscriptionRenewalDate || "unknown"
-  }, interval=${item.subscriptionIntervalMonths ?? 12} months, required=${
-    subscriptionRequired ? "true" : "false"
-  }`;
-  logHistory({
-    type: "subscription_updated",
-    text: `${item.name} subscription updated.`,
-    equipmentId: String(item.id),
-    equipmentSnapshot: {
-      name: item.name,
-      model: item.model,
-      serialNumber: item.serialNumber,
-    },
-    notes,
-  });
-  if (elements.subscriptionInterval) {
-    elements.subscriptionInterval.value = "";
-  }
-  saveState();
-  refreshUI();
-}
-
 function handleAddEquipment(event) {
   event.preventDefault();
   if (
@@ -2582,6 +2527,11 @@ function handleAddEquipment(event) {
   const lastCalibrationDate = calibrationRequired
     ? elements.addEquipmentLastCalibration?.value ?? ""
     : "";
+  const subscriptionRequired =
+    elements.addEquipmentSubscriptionRequired?.checked ?? false;
+  const subscriptionRenewalDate = subscriptionRequired
+    ? elements.addEquipmentSubscriptionDate?.value ?? ""
+    : "";
   if (!name) {
     return;
   }
@@ -2597,7 +2547,10 @@ function handleAddEquipment(event) {
     calibrationIntervalMonths: calibrationInterval,
     lastCalibrationDate,
   });
-  const subscriptionDetails = normalizeSubscriptionFields({});
+  const subscriptionDetails = normalizeSubscriptionFields({
+    subscriptionRequired,
+    subscriptionRenewalDate,
+  });
 
   const newItemId = crypto.randomUUID();
   state.equipment.push({
@@ -2625,6 +2578,22 @@ function handleAddEquipment(event) {
     toLocation: location,
     statusTo: status,
   });
+  if (
+    subscriptionDetails.subscriptionRequired ||
+    subscriptionDetails.subscriptionRenewalDate
+  ) {
+    logHistory({
+      type: "subscription_updated",
+      text: `${name} subscription updated.`,
+      equipmentId: String(newItemId),
+      equipmentSnapshot: {
+        name,
+        model,
+        serialNumber,
+      },
+      notes: buildSubscriptionNotes(subscriptionDetails),
+    });
+  }
   elements.addEquipmentName.value = "";
   elements.addEquipmentModel.value = "";
   elements.addEquipmentSerial.value = "";
@@ -2641,6 +2610,13 @@ function handleAddEquipment(event) {
   if (elements.addEquipmentLastCalibration) {
     elements.addEquipmentLastCalibration.value = "";
   }
+  if (elements.addEquipmentSubscriptionRequired) {
+    elements.addEquipmentSubscriptionRequired.checked = false;
+  }
+  if (elements.addEquipmentSubscriptionDate) {
+    elements.addEquipmentSubscriptionDate.value = "";
+  }
+  syncAddSubscriptionInputs({ clearWhenDisabled: false });
   toggleSerialWarning(
     elements.addEquipmentSerialWarning,
     "",
@@ -2772,8 +2748,6 @@ function handleImportSubmit() {
       calibrationIntervalMonths: calibrationDetails.calibrationIntervalMonths,
       lastCalibrationDate: calibrationDetails.lastCalibrationDate,
       subscriptionRequired: subscriptionDetails.subscriptionRequired,
-      subscriptionIntervalMonths:
-        subscriptionDetails.subscriptionIntervalMonths,
       subscriptionRenewalDate: subscriptionDetails.subscriptionRenewalDate,
       lastMoved: now,
     };
@@ -2811,7 +2785,9 @@ function syncEditForm() {
     !elements.editEquipmentCalibrationRequired ||
     !elements.editEquipmentCalibrationInterval ||
     !elements.editEquipmentCalibrationIntervalCustom ||
-    !elements.editEquipmentLastCalibration
+    !elements.editEquipmentLastCalibration ||
+    !elements.editEquipmentSubscriptionRequired ||
+    !elements.editEquipmentSubscriptionDate
   ) {
     return;
   }
@@ -2847,7 +2823,17 @@ function syncEditForm() {
   }
 
   elements.editEquipmentLastCalibration.value = item.lastCalibrationDate ?? "";
+  const subscriptionRequired = Boolean(item.subscriptionRequired);
+  if (elements.editEquipmentSubscriptionRequired) {
+    elements.editEquipmentSubscriptionRequired.checked = subscriptionRequired;
+  }
+  if (elements.editEquipmentSubscriptionDate) {
+    elements.editEquipmentSubscriptionDate.value = subscriptionRequired
+      ? item.subscriptionRenewalDate ?? ""
+      : "";
+  }
   syncEditCalibrationInputs();
+  syncEditSubscriptionInputs({ clearWhenDisabled: false });
   clearEditNameError();
   toggleNameWarning(
     elements.editEquipmentNameWarning,
@@ -2874,7 +2860,9 @@ function resetEditForm() {
     !elements.editEquipmentCalibrationRequired ||
     !elements.editEquipmentCalibrationInterval ||
     !elements.editEquipmentCalibrationIntervalCustom ||
-    !elements.editEquipmentLastCalibration
+    !elements.editEquipmentLastCalibration ||
+    !elements.editEquipmentSubscriptionRequired ||
+    !elements.editEquipmentSubscriptionDate
   ) {
     return;
   }
@@ -2893,7 +2881,14 @@ function resetEditForm() {
   elements.editEquipmentCalibrationInterval.value = "12";
   elements.editEquipmentCalibrationIntervalCustom.value = "";
   elements.editEquipmentLastCalibration.value = "";
+  if (elements.editEquipmentSubscriptionRequired) {
+    elements.editEquipmentSubscriptionRequired.checked = false;
+  }
+  if (elements.editEquipmentSubscriptionDate) {
+    elements.editEquipmentSubscriptionDate.value = "";
+  }
   syncEditCalibrationInputs();
+  syncEditSubscriptionInputs({ clearWhenDisabled: false });
   clearEditNameError();
   clearNameWarning(elements.editEquipmentNameWarning);
   clearSerialWarning(elements.editEquipmentSerialWarning);
@@ -2932,6 +2927,46 @@ function syncEditCalibrationInputs() {
       "is-hidden",
       !isRequired
     );
+  }
+}
+
+function syncAddSubscriptionInputs({ clearWhenDisabled = true } = {}) {
+  if (
+    !elements.addEquipmentSubscriptionRequired ||
+    !elements.addEquipmentSubscriptionDate
+  ) {
+    return;
+  }
+  const isRequired = elements.addEquipmentSubscriptionRequired.checked;
+  elements.addEquipmentSubscriptionDate.disabled = !isRequired;
+  if (elements.addEquipmentSubscriptionDateField) {
+    elements.addEquipmentSubscriptionDateField.classList.toggle(
+      "is-hidden",
+      !isRequired
+    );
+  }
+  if (!isRequired && clearWhenDisabled) {
+    elements.addEquipmentSubscriptionDate.value = "";
+  }
+}
+
+function syncEditSubscriptionInputs({ clearWhenDisabled = true } = {}) {
+  if (
+    !elements.editEquipmentSubscriptionRequired ||
+    !elements.editEquipmentSubscriptionDate
+  ) {
+    return;
+  }
+  const isRequired = elements.editEquipmentSubscriptionRequired.checked;
+  elements.editEquipmentSubscriptionDate.disabled = !isRequired;
+  if (elements.editEquipmentSubscriptionDateField) {
+    elements.editEquipmentSubscriptionDateField.classList.toggle(
+      "is-hidden",
+      !isRequired
+    );
+  }
+  if (!isRequired && clearWhenDisabled) {
+    elements.editEquipmentSubscriptionDate.value = "";
   }
 }
 
@@ -3128,12 +3163,26 @@ function handleEditEquipmentSubmit(event) {
   const lastCalibrationDate = calibrationRequired
     ? elements.editEquipmentLastCalibration?.value ?? ""
     : "";
+  const subscriptionRequired =
+    elements.editEquipmentSubscriptionRequired?.checked ?? false;
+  const subscriptionRenewalDate = subscriptionRequired
+    ? elements.editEquipmentSubscriptionDate?.value ?? ""
+    : "";
 
   const calibrationDetails = normalizeCalibrationFields({
     calibrationRequired,
     calibrationIntervalMonths: calibrationInterval,
     lastCalibrationDate,
   });
+  const subscriptionDetails = normalizeSubscriptionFields({
+    subscriptionRequired,
+    subscriptionRenewalDate,
+  });
+  const subscriptionChanged =
+    Boolean(item.subscriptionRequired) !==
+      subscriptionDetails.subscriptionRequired ||
+    (item.subscriptionRenewalDate ?? "") !==
+      subscriptionDetails.subscriptionRenewalDate;
 
   const updatedFields = {
     name,
@@ -3166,6 +3215,11 @@ function handleEditEquipmentSubmit(event) {
   item.calibrationIntervalMonths =
     calibrationDetails.calibrationIntervalMonths;
   item.lastCalibrationDate = calibrationDetails.lastCalibrationDate;
+  item.subscriptionRequired = subscriptionDetails.subscriptionRequired;
+  item.subscriptionRenewalDate =
+    subscriptionDetails.subscriptionRequired
+      ? subscriptionDetails.subscriptionRenewalDate
+      : "";
 
   if (changedFields.length > 0) {
     const changedLabel = changedFields.join(", ");
@@ -3179,6 +3233,22 @@ function handleEditEquipmentSubmit(event) {
         serialNumber: item.serialNumber,
       },
       notes: changedLabel,
+    });
+  }
+  if (subscriptionChanged) {
+    logHistory({
+      type: "subscription_updated",
+      text: `${name} subscription updated.`,
+      equipmentId: String(item.id),
+      equipmentSnapshot: {
+        name,
+        model: item.model,
+        serialNumber: item.serialNumber,
+      },
+      notes: buildSubscriptionNotes({
+        subscriptionRequired: item.subscriptionRequired,
+        subscriptionRenewalDate: item.subscriptionRenewalDate,
+      }),
     });
   }
 
@@ -3352,24 +3422,10 @@ if (elements.calibrationForm) {
   );
 }
 
-if (elements.subscriptionForm) {
-  elements.subscriptionForm.addEventListener(
-    "submit",
-    handleSubscriptionSubmit
-  );
-}
-
 if (elements.calibrationEquipment) {
   elements.calibrationEquipment.addEventListener(
     "change",
     syncCalibrationForm
-  );
-}
-
-if (elements.subscriptionEquipment) {
-  elements.subscriptionEquipment.addEventListener(
-    "change",
-    syncSubscriptionForm
   );
 }
 
@@ -3388,6 +3444,13 @@ if (elements.addEquipmentCalibrationInterval) {
   elements.addEquipmentCalibrationInterval.addEventListener(
     "change",
     syncCalibrationInputs
+  );
+}
+
+if (elements.addEquipmentSubscriptionRequired) {
+  elements.addEquipmentSubscriptionRequired.addEventListener(
+    "change",
+    syncAddSubscriptionInputs
   );
 }
 
@@ -3457,6 +3520,13 @@ if (elements.editEquipmentCalibrationInterval) {
   );
 }
 
+if (elements.editEquipmentSubscriptionRequired) {
+  elements.editEquipmentSubscriptionRequired.addEventListener(
+    "change",
+    syncEditSubscriptionInputs
+  );
+}
+
 if (elements.editEquipmentSerial) {
   const handleEditSerialInput = () => {
     toggleSerialWarning(
@@ -3510,6 +3580,8 @@ initTabs();
 refreshUI();
 syncCalibrationInputs();
 syncEditCalibrationInputs();
+syncAddSubscriptionInputs();
+syncEditSubscriptionInputs();
 resetImportState();
 
 if (elements.adminModeToggle) {

--- a/index.html
+++ b/index.html
@@ -168,8 +168,7 @@
               <section class="card">
                 <h2>Console</h2>
                 <p>
-                  Use the console to log moves, record calibration, or renew
-                  subscriptions.
+                  Use the console to log moves or record calibration updates.
                 </p>
 
                 <div class="console">
@@ -225,32 +224,6 @@
                     <button type="submit">Save calibration</button>
                   </form>
 
-                  <form id="subscription-form" class="panel">
-                    <h3>Record subscription</h3>
-                    <label>
-                      Equipment
-                      <select id="subscription-equipment"></select>
-                    </label>
-                    <label>
-                      Renewal date
-                      <input id="subscription-date" type="date" />
-                    </label>
-                    <label>
-                      Interval months (optional override)
-                      <input
-                        id="subscription-interval"
-                        type="number"
-                        min="1"
-                        step="1"
-                        placeholder="e.g. 18"
-                      />
-                    </label>
-                    <label class="checkbox-field">
-                      Subscription required
-                      <input id="subscription-required" type="checkbox" />
-                    </label>
-                    <button type="submit">Save subscription</button>
-                  </form>
                 </div>
 
                 <div class="history">
@@ -389,6 +362,20 @@
                     Last calibration date
                     <input id="new-equipment-last-calibration" type="date" />
                   </label>
+                  <label class="checkbox-field">
+                    Subscription required
+                    <input
+                      id="new-equipment-subscription-required"
+                      type="checkbox"
+                    />
+                  </label>
+                  <label id="new-equipment-subscription-date-field">
+                    Subscription renewal date
+                    <input
+                      id="new-equipment-subscription-date"
+                      type="date"
+                    />
+                  </label>
                   <button type="submit">Add equipment</button>
                 </form>
 
@@ -471,6 +458,20 @@
                   <label id="edit-equipment-last-calibration-field">
                     Last calibration date
                     <input id="edit-equipment-last-calibration" type="date" />
+                  </label>
+                  <label class="checkbox-field">
+                    Subscription required
+                    <input
+                      id="edit-equipment-subscription-required"
+                      type="checkbox"
+                    />
+                  </label>
+                  <label id="edit-equipment-subscription-date-field">
+                    Subscription renewal date
+                    <input
+                      id="edit-equipment-subscription-date"
+                      type="date"
+                    />
                   </label>
                   <div class="panel-actions">
                     <button type="submit">Save changes</button>

--- a/styles.css
+++ b/styles.css
@@ -214,6 +214,18 @@ select:focus {
   border: 1px solid var(--border);
 }
 
+.status-with-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.status-meta {
+  font-size: 11px;
+  color: var(--muted);
+}
+
 .location-summary {
   margin-top: 20px;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- Consolidate subscription management into the Admin workflow so subscription data is edited only with Add/Edit equipment rather than an Operations console panel.
- Make the renewal date the single source of truth and remove subscription interval from UI and calculations.
- Preserve compatibility with existing stored data by ignoring any `subscriptionIntervalMonths` values during normalization and import.

### Description
- Removed the “Record subscription” panel and related form/handlers from the Operations console and eliminated the `subscription` console select from equipment options in the Operations view. (`index.html`, `app.js`).
- Added subscription controls to Admin → Add equipment and Admin → Edit equipment: a `Subscription required` checkbox and a `Subscription renewal date` date input, together with sync logic that disables/hides and clears the date when not required (new `syncAddSubscriptionInputs` and `syncEditSubscriptionInputs` in `app.js`).
- Removed all UI and data-flow usage of `subscriptionIntervalMonths` (seed data trimmed, normalization/import/export updated to ignore the interval) and stopped using it in subscription update flows and logs. (`app.js`).
- Computed subscription status solely from `subscriptionRenewalDate` (30-day warning window) with statuses: `Not required`, `Unknown`, `Overdue`, `Due soon`, and `OK`; subscription badge rendering now optionally shows the renewal date next to the badge and CSS added for the badge/date layout (`styles.css`).
- Kept subscription filter and stats working and based on the computed status; retained history logging semantics but changed admin flows to log `subscription_updated` entries containing `equipmentId`, a snapshot, and a notes string describing the new `subscriptionRequired` and `subscriptionRenewalDate` values (helper `buildSubscriptionNotes`).

### Testing
- Started a lightweight static server (`python -m http.server`) and performed a browser smoke test using Playwright to render the app; an initial Playwright attempt to toggle admin timed out, a subsequent DOM-content-loaded run produced a full-page screenshot of the Operations view showing the subscription console removed (screenshot artifact captured successfully). (smoke test succeeded after a retry).
- Ran automated source checks with `rg` to confirm removal of the operations subscription form and references to `subscriptionIntervalMonths`, and verified the new Admin fields and sync handlers are present in the codebase; these checks passed. 
- No unit test suite was present or run; only the described runtime smoke and grep-based checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ff7eb5808333a27487a33c67e1a2)