### PR TITLE
Add per-equipment conditionReference and condition-check UI for moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,80 @@
                         placeholder="Customer name, demo date..."
                       />
                     </label>
+                    <div class="condition-section">
+                      <h4>Condition check</h4>
+                      <div class="condition-grid">
+                        <label>
+                          Condition rating
+                          <select id="move-condition-rating">
+                            <option value="Excellent">Excellent</option>
+                            <option value="Good" selected>Good</option>
+                            <option value="Fair">Fair</option>
+                            <option value="Poor">Poor</option>
+                            <option value="Damaged">Damaged</option>
+                          </select>
+                        </label>
+                        <label>
+                          Contents OK?
+                          <select id="move-contents-ok">
+                            <option value="Yes" selected>Yes</option>
+                            <option value="No">No</option>
+                          </select>
+                        </label>
+                        <label>
+                          Functional OK?
+                          <select id="move-functional-ok">
+                            <option value="Yes" selected>Yes</option>
+                            <option value="No">No</option>
+                          </select>
+                        </label>
+                      </div>
+                      <label>
+                        Condition notes
+                        <textarea
+                          id="move-condition-notes"
+                          rows="3"
+                          placeholder="Record any issues if checks failed..."
+                        ></textarea>
+                        <span
+                          id="move-condition-notes-error"
+                          class="field-error is-hidden"
+                        >
+                          Notes are required when a condition check fails.
+                        </span>
+                      </label>
+                      <details class="reference-panel">
+                        <summary>What should I check?</summary>
+                        <div class="reference-panel-body">
+                          <div class="reference-section">
+                            <h5>Contents checklist</h5>
+                            <ul
+                              id="move-contents-checklist"
+                              class="reference-list"
+                            ></ul>
+                            <p
+                              id="move-contents-checklist-empty"
+                              class="reference-empty"
+                            >
+                              No reference defined for this equipment.
+                            </p>
+                          </div>
+                          <div class="reference-section">
+                            <h5>Functional check guide</h5>
+                            <ul
+                              id="move-functional-checklist"
+                              class="reference-list"
+                            ></ul>
+                            <p
+                              id="move-functional-checklist-empty"
+                              class="reference-empty"
+                            >
+                              No reference defined for this equipment.
+                            </p>
+                          </div>
+                        </div>
+                      </details>
+                    </div>
                     <button type="submit">Record move</button>
                   </form>
 
@@ -472,6 +546,22 @@
                       id="edit-equipment-subscription-date"
                       type="date"
                     />
+                  </label>
+                  <label>
+                    Contents checklist (reference)
+                    <textarea
+                      id="edit-equipment-contents-checklist"
+                      rows="4"
+                      placeholder="List contents to verify, one per line..."
+                    ></textarea>
+                  </label>
+                  <label>
+                    Functional check guide (reference)
+                    <textarea
+                      id="edit-equipment-functional-checklist"
+                      rows="4"
+                      placeholder="List functional checks, one per line..."
+                    ></textarea>
                   </label>
                   <div class="panel-actions">
                     <button type="submit">Save changes</button>

--- a/styles.css
+++ b/styles.css
@@ -185,12 +185,14 @@ h1 {
 
 select,
 input,
+textarea,
 button {
   font: inherit;
 }
 
 select,
-input {
+input,
+textarea {
   width: 100%;
   padding: 10px 12px;
   border-radius: 10px;
@@ -198,8 +200,14 @@ input {
   background: #fff;
 }
 
+textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
 input:focus,
-select:focus {
+select:focus,
+textarea:focus {
   outline: 2px solid rgba(75, 110, 245, 0.35);
   border-color: var(--accent);
 }
@@ -378,6 +386,68 @@ tr:last-child td {
   gap: 6px;
   font-size: 13px;
   color: var(--muted);
+}
+
+.condition-section {
+  display: grid;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.condition-section h4 {
+  margin: 0;
+  font-size: 14px;
+  color: var(--ink);
+}
+
+.condition-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.reference-panel {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  background: #fff;
+}
+
+.reference-panel summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.reference-panel-body {
+  display: grid;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.reference-section h5 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.reference-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ink);
+}
+
+.reference-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
 }
 
 .panel-actions {


### PR DESCRIPTION
### Motivation
- Provide per-equipment guidance to staff during condition checks when logging moves so they know what to verify for contents and functionality.
- Keep references admin-editable and read-only for operators, and avoid storing checklist items on moves while still capturing check results and notes.

### Description
- Data model: add `conditionReference` on each equipment item with `contentsChecklist` and `functionalChecklist` defaulting to empty strings and normalize via `normalizeConditionReference` so existing data is migrated safely.
- Admin UI: add two admin-only textarea inputs `edit-equipment-contents-checklist` and `edit-equipment-functional-checklist` to edit equipment and persist into `item.conditionReference` when saving.`
- Move logging UI: add condition inputs (`move-condition-rating`, `move-contents-ok`, `move-functional-ok`, `move-condition-notes`) and a collapsible read-only panel titled “What should I check?” that renders the equipment `contentsChecklist` and `functionalChecklist` as bulleted lists or shows “No reference defined for this equipment.”
- Validation and logging: require `Condition notes` when either contents or functional check is `No`, but do not change existing validation for other fields; when a move is logged the code stores only the check results (`conditionRating`, `contentsOk`, `functionalOk`, `conditionNotes`) with the move entry and does not persist checklist items per move.
- Helpers and styling: add `parseChecklistEntries`, `renderChecklistList`, `syncMoveConditionReference`, and `syncMoveConditionNotesError` in `app.js`, wire change/input handlers to keep the reference panel and validation in sync, and add CSS for the condition section and reference panel in `styles.css`.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the app which launched successfully; no automated page assertions were completed.
- Attempted an automated Playwright screenshot to verify the expanded reference panel but the Playwright job timed out (failed). No other automated tests were run or completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698302ebcd0c8333a19486b97079a365)