### PR TITLE
Add shipping details to move logging (carrier, tracking, ship/ETA)

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,37 @@
                         placeholder="Customer name, demo date..."
                       />
                     </label>
+                    <fieldset class="shipping-section">
+                      <legend>Shipping details (optional)</legend>
+                      <label>
+                        Carrier / Courier
+                        <select id="move-shipping-carrier">
+                          <option value="">Select carrier...</option>
+                          <option value="Team Global Express">Team Global Express</option>
+                          <option value="TNT/FedEx">TNT/FedEx</option>
+                          <option value="DHL">DHL</option>
+                          <option value="StarTrack">StarTrack</option>
+                          <option value="Toll">Toll</option>
+                          <option value="Other">Other</option>
+                        </select>
+                      </label>
+                      <label>
+                        Tracking number
+                        <input id="move-shipping-tracking" type="text" />
+                      </label>
+                      <label>
+                        Ship date
+                        <input id="move-shipping-ship-date" type="date" />
+                      </label>
+                      <label>
+                        ETA date
+                        <input id="move-shipping-eta-date" type="date" />
+                      </label>
+                      <label class="inline-checkbox">
+                        <input id="move-auto-in-transit" type="checkbox" checked />
+                        Auto-set status to <strong>In transit</strong> for inter-office moves
+                      </label>
+                    </fieldset>
                     <div class="condition-section">
                       <h4>Condition check</h4>
                       <div class="condition-grid">

--- a/styles.css
+++ b/styles.css
@@ -388,6 +388,33 @@ tr:last-child td {
   color: var(--muted);
 }
 
+
+.shipping-section {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.shipping-section legend {
+  padding: 0 6px;
+  font-size: 13px;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.inline-checkbox {
+  display: flex !important;
+  align-items: center;
+  gap: 8px;
+}
+
+.inline-checkbox input[type="checkbox"] {
+  width: auto;
+}
+
 .condition-section {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
### Motivation
- Provide basic shipping metadata when logging moves so courier handovers and tracking can be recorded alongside move entries. 
- Allow optionally auto-marking inter-office moves as `In transit` to surface transit state in the UI.
- Persist shipping data with moves without breaking existing move logs stored in localStorage.

### Description
- UI: added a `fieldset` with shipping inputs to the `Log a move` form in `index.html` including `#move-shipping-carrier`, `#move-shipping-tracking`, `#move-shipping-ship-date`, `#move-shipping-eta-date`, and an `#move-auto-in-transit` checkbox. 
- Styling: added `.shipping-section` and `.inline-checkbox` styles in `styles.css` to match existing panels.
- Data model and normalization: introduced `normalizeShippingDetails(shipping)` and included `shipping` in normalized move entries returned by `normalizeHistoryEntry` so moves store `{ carrier, trackingNumber, shipDate, etaDate }` safely (backwards compatible with legacy logs). 
- Submit & persistence: updated `handleMoveSubmit` in `app.js` to collect shipping fields (defaulting `shipDate` to today when empty), persist `shipping` on the move log entry, reset shipping inputs after submit, and save to `localStorage` via the existing `saveState` flow. 
- In-transit behavior & equipment view: added an optional auto-set rule to set item status to `In transit` for inter-office moves when the checkbox is enabled, added `getLatestMoveEntryForEquipment`/`getEquipmentLocationDisplay` helpers, and updated equipment table rendering to show `In transit (From → To)` and an `In transit` badge where appropriate. 
- Moves table: added a `Shipping` column to the Moves log and a `getShippingSummary` helper to display carrier/tracking/ETA when present.

### Testing
- `node --check app.js` was run and succeeded to validate JS syntax. 
- Automated browser smoke tests using Playwright were attempted; a Firefox-based run captured a UI screenshot of the updated form and moves view (artifact: `artifacts/moves-shipping.png`) and provided partial verification that shipping appears in the moves table and `localStorage` contains the `shipping` payload on successful runs. 
- Some end-to-end Playwright attempts timed out or hit environment constraints (seeded checklist lock preventing submission for some seed items and intermittent headless-browser instability), so full automated E2E verification was partially blocked but manual/partial automated checks confirmed the main flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843fc7b07083338b687e6900fc1b30)