### PR TITLE
Make “In transit” a computed shipping status and add Mark received flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,10 +220,9 @@
                         ETA date
                         <input id="move-shipping-eta-date" type="date" />
                       </label>
-                      <label class="inline-checkbox">
-                        <input id="move-auto-in-transit" type="checkbox" checked />
-                        Auto-set status to <strong>In transit</strong> for inter-office moves
-                      </label>
+                      <p id="move-shipping-override-note" class="field-warning is-hidden">
+                      Shipping details are active: status is shown as <strong>In transit</strong> until received.
+                    </p>
                     </fieldset>
                     <div class="condition-section">
                       <h4>Condition check</h4>

--- a/styles.css
+++ b/styles.css
@@ -687,6 +687,11 @@ button:disabled {
   color: var(--accent-dark);
 }
 
+
+.tag--in-transit {
+  background: rgba(245, 158, 11, 0.2);
+  color: #9a6100;
+}
 @media (max-width: 900px) {
   .grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Remove user-selectable "In transit" to prevent conflicts between stored status and active shipping details.
- Ensure UI and filters/counts reflect a shipping-driven effective status so shipped items surface as "In transit" while in transit.
- Provide a simple receive action to complete shipping without mutating stored business status implicitly.

### Description
- Removed "In transit" from editable status options and introduced `statusFilterOptions = [...editableStatusOptions, "In transit"]` so it remains available for filters but not user selection. (updates in `app.js`, `index.html`).
- Added shipping/effective-status helpers: `hasShippingCoreDetails`, `getLatestShippingMoveEntryForEquipment`, `isShippingActive`, and `getEffectiveStatus`, and switched search, filtering and stats to use `getEffectiveStatus(item)` instead of `item.status` (all in `app.js`).
- Changed move logging to stop forcing `item.status = "In transit"`; move entries include a `shipping.deliveredAt` field and `statusTo` records the effective status at time of logging (in `handleMoveSubmit`).
- Added a shipping override UX in the move form: a visible note and auto-disable of the "Status (optional)" selector while shipping details are present (`syncMoveShippingStatusOverride` + listeners, `index.html`, `app.js`).
- Implemented a "Mark received" action in the Moves view (`handleMarkReceived`) that sets `deliveredAt`, updates equipment `location`/`lastMoved`, logs a `received` history entry, and immediately causes `getEffectiveStatus` to revert display to stored status (changes in `app.js`).
- Migrated legacy stored `status: "In transit"` during normalization to a supported business status and emitted a correction entry (in `normalizeState`).
- Added distinct badge styling for effective "In transit" (`.tag--in-transit` in `styles.css`) and updated table/status badge rendering to use `getEffectiveStatus`.

### Testing
- Ran `node --check app.js` to validate syntax; the check succeeded.
- Executed browser end-to-end checks using an automated Playwright script against the running dev server which asserted: shipping move disables status selector and produces an effective "In transit" display; the status filter includes and returns "In transit" rows; the Moves view exposes a "Mark received" action which, when clicked, clears the effective "In transit" display and reverts to stored status; and a legacy equipment record with stored `status: "In transit"` is migrated to `Available` safely; all assertions passed.
- Captured a UI screenshot artifact during testing at `artifacts/shipping-effective-status.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698444f7423483339b193293474d725c)