### PR TITLE
Require explicit condition checklist confirmation before move logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,8 +230,9 @@
                         <label>
                           Condition rating
                           <select id="move-condition-rating">
+                            <option value="" selected>Select...</option>
                             <option value="Excellent">Excellent</option>
-                            <option value="Good" selected>Good</option>
+                            <option value="Good">Good</option>
                             <option value="Fair">Fair</option>
                             <option value="Poor">Poor</option>
                             <option value="Damaged">Damaged</option>
@@ -240,14 +241,16 @@
                         <label>
                           Contents OK?
                           <select id="move-contents-ok">
-                            <option value="Yes" selected>Yes</option>
+                            <option value="" selected>Select...</option>
+                            <option value="Yes">Yes</option>
                             <option value="No">No</option>
                           </select>
                         </label>
                         <label>
                           Functional OK?
                           <select id="move-functional-ok">
-                            <option value="Yes" selected>Yes</option>
+                            <option value="" selected>Select...</option>
+                            <option value="Yes">Yes</option>
                             <option value="No">No</option>
                           </select>
                         </label>
@@ -263,7 +266,7 @@
                           id="move-condition-notes-error"
                           class="field-error is-hidden"
                         >
-                          Notes are required when a condition check fails.
+                          Please add notes for failed checks.
                         </span>
                       </label>
                       <details class="reference-panel">
@@ -311,6 +314,9 @@
                       >
                         Go to Admin → Edit equipment
                       </button>
+                    </p>
+                    <p id="move-submit-blocked" class="field-warning">
+                      Complete the condition checklist before recording the move.
                     </p>
                     <button type="submit" id="move-submit">
                       Record move


### PR DESCRIPTION
### Motivation
- Prevent accidental move submissions by removing implicit defaults from condition inputs so users must actively confirm each item. 
- Ensure failures are visible and documented by requiring notes when any check fails or overall rating is poor/damaged.

### Description
- Replace default selections with a `Select...` placeholder for `#move-condition-rating`, `#move-contents-ok`, and `#move-functional-ok` in `index.html` and update the notes helper to "Please add notes for failed checks.".
- Add validation helpers in `app.js`: `isMoveConditionChecklistComplete`, `hasMoveConditionFailures`, and `validateMoveConditionChecklist` to disable `#move-submit` until the checklist is complete and valid, and to show an inline blocked message `#move-submit-blocked` when blocked.
- Require a non-empty notes field when any checklist item is `No` or rating is `Poor`/`Damaged`, and surface the notes error inline when needed.
- Reset per-move condition inputs via `resetMoveConditionInputs` when equipment changes and after a successful move so selections do not carry across moves.
- Persist `conditionRating`, `contentsOk`, `functionalOk`, and `conditionNotes` into the move log entry and render a condition summary in the Moves view while gracefully falling back to `—` for older entries lacking condition data.

### Testing
- Ran `node --check app.js` with no syntax errors (passed).
- Served the app with `python -m http.server 4173` and exercised the UI with Playwright scripts to verify: initial selects are empty and `Record move` is disabled (passed), partial checklist selections keep submit disabled (passed), setting a check to `No` blocks submit until notes are provided and shows the notes requirement (passed).
- Note: the seeded dataset used during tests had no equipment with a defined condition checklist, so the end-to-end path that enables submit because `checklistDefined` is true could not be exercised in this environment (observed and reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984483526b48333a65716998a8e889f)