### PR TITLE
Show shipping details in moves and in-transit equipment rows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -234,6 +234,46 @@ textarea:focus {
   color: var(--muted);
 }
 
+.moves-shipping-cell {
+  white-space: pre-line;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.shipping-details-card {
+  background: #f7f9ff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.shipping-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px 14px;
+}
+
+.shipping-details-grid div {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.shipping-details-grid strong {
+  color: var(--text);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.icon-button--inline {
+  width: fit-content;
+  margin-top: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+}
+
 .location-summary {
   margin-top: 20px;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- Make shipping details (carrier, tracking, ship date, ETA, delivered date, route, notes) visible and searchable so moves and in-transit equipment are informative and historical shipping data is preserved on the move log entry.
- Surface compact shipping metadata inline with existing UI (avoid adding many columns) and provide a lightweight details view for active shipments.
- Ensure older records without shipping objects do not break rendering and shipping is treated as inactive once marked received.

### Description
- Persist and preserve shipping on move log entries (shipping object written by the move form and kept on the log entry). 
- Add `getActiveShippingMoveEntryForEquipment`, `getCompactShippingMeta`, and `getMovesShippingSummary` to locate active shipping and format compact/expanded shipping displays, and use them in equipment and moves rendering.
- Show compact shipping meta under the equipment status badge for active shipments and add a small `View` action that expands an inline details row with carrier, tracking (copy button), ship date, ETA, delivered date, route, and notes.
- Extend filtering/search to match shipping carrier/tracking text for both the equipment table (`getFilteredEquipment`) and the Moves log (`getFilteredMoves`), and render moves shipping as a compact multi-line cell (`Carrier: X` and `Shipped … • ETA …`).
- Add click handlers for toggling equipment shipping details and for copying tracking numbers, plus CSS rules to style the compact shipping cell and expanded details panel.

### Testing
- Ran static JS syntax checking with `node --check app.js`, which completed successfully.
- Attempted automated UI validation via a Playwright script to inject a move, open the equipment details row and the Moves tab, and capture screenshots, but the headless browser process crashed in this environment (SIGSEGV) so screenshots could not be produced.
- Performed local smoke checks by starting a simple HTTP server and exercised the codepaths while debugging to ensure no runtime errors were introduced (no app initialization failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984499297688333b7975c361d377c67)