### PR TITLE
Refactor condition tracking into first-class equipment state

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@
                         <th>Location</th>
                         <th>Calibration</th>
                         <th>Subscription</th>
+                        <th>Condition</th>
                         <th>Last moved</th>
                       </tr>
                     </thead>
@@ -234,8 +235,8 @@
                             <option value="Excellent">Excellent</option>
                             <option value="Good">Good</option>
                             <option value="Fair">Fair</option>
-                            <option value="Poor">Poor</option>
-                            <option value="Damaged">Damaged</option>
+                            <option value="Needs attention">Needs attention</option>
+                            <option value="Unserviceable">Unserviceable</option>
                           </select>
                         </label>
                         <label>
@@ -722,6 +723,15 @@
         </div>
       </main>
     </div>
+
+
+    <dialog id="condition-history-modal" class="condition-history-modal">
+      <div class="condition-history-header">
+        <h3 id="condition-history-title">Condition history</h3>
+        <button type="button" class="icon-button" id="condition-history-close">Close</button>
+      </div>
+      <ul id="condition-history-list" class="condition-history-list"></ul>
+    </dialog>
 
     <script src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -737,3 +737,48 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 }
+
+.condition-badge {
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.condition-badge--warn {
+  background: rgba(245, 158, 11, 0.2);
+  color: #9a6100;
+}
+
+.condition-history-modal {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  width: min(680px, 92vw);
+}
+
+.condition-history-modal::backdrop {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.condition-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.condition-history-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.condition-history-list li {
+  background: #f7f9ff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--muted);
+}


### PR DESCRIPTION
### Motivation
- Remove condition noise from move notes and make condition a single source of truth owned by equipment rather than implicitly tied to moves. 
- Record condition checks as structured, auditable data so history and current state are reliable and machine-readable. 
- Surface condition clearly in the UI (compact badge, last-checked meta, history) and prevent unvalidated moves from silently changing equipment condition.

### Description
- Introduces first-class equipment condition fields on each item: `conditionRating`, `conditionContentsOk`, `conditionFunctionalOk`, `conditionLastCheckedAt`, `conditionLastCheckedBy`, and `conditionLastNotes`, and initializes them in the seeded/default state. 
- Moves now store structured condition data as `entry.condition = { rating, contentsOk, functionalOk, notes, checkedAt, checkedBy }` with normalization helpers that accept legacy flat fields for backward compatibility. 
- Move submission flow only updates the equipment current condition when a complete, validated condition check is performed during the move; moves without a completed check do not modify equipment condition. 
- Removes automatic injection of condition text into move `notes` and adds a dedicated Moves table `Condition` column that displays `formatConditionSummary(entry.condition)` or `—` if no condition was recorded for that move. 
- Enhances the Equipment table Condition UX with a clickable condition badge showing `equipment.conditionRating`, a small `Last checked: <date>` secondary line, and a `⚠️` indicator when `conditionContentsOk === false` or `conditionFunctionalOk === false`. Clicking the badge opens a lightweight modal/timeline built from existing move entries that contain `entry.condition` (newest → oldest). 
- Back-compat and migration: legacy flat condition fields are normalized to the new `entry.condition` structure when present, and old logs lacking structured condition data render safely (shows `—` or preserves existing notes). 
- Files changed: `app.js`, `index.html`, `styles.css` (core logic, UI column, modal, and styling). 

### Testing
- Ran `node --check app.js` to validate JS syntax and basic module integrity; this check passed. 
- Attempted an automated browser screenshot via Playwright and served the app with `python -m http.server`, but the Playwright navigation/screenshot run failed in this environment (`ERR_EMPTY_RESPONSE` / `ERR_FILE_NOT_FOUND`), so no UI screenshot artifact was produced. 
- No other automated test harness exists in the repo; changes include normalization and defensive checks to keep legacy logs rendering safely.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844dcfa48483338ed70c0af8c0d5b1)