### PR TITLE
Add right-side condition history drawer for equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,13 +725,29 @@
     </div>
 
 
-    <dialog id="condition-history-modal" class="condition-history-modal">
+    <div id="condition-history-backdrop" class="condition-history-backdrop" hidden></div>
+    <aside
+      id="condition-history-drawer"
+      class="condition-history-drawer"
+      aria-hidden="true"
+      aria-label="Condition history drawer"
+    >
       <div class="condition-history-header">
-        <h3 id="condition-history-title">Condition history</h3>
-        <button type="button" class="icon-button" id="condition-history-close">Close</button>
+        <div>
+          <h3 id="condition-history-title">Condition history</h3>
+          <p id="condition-history-equipment" class="condition-history-equipment"></p>
+        </div>
+        <button
+          type="button"
+          class="icon-button"
+          id="condition-history-close"
+          aria-label="Close condition history"
+        >
+          ✕
+        </button>
       </div>
       <ul id="condition-history-list" class="condition-history-list"></ul>
-    </dialog>
+    </aside>
 
     <script src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -748,37 +748,96 @@ button:disabled {
   color: #9a6100;
 }
 
-.condition-history-modal {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 14px;
-  width: min(680px, 92vw);
+.inline-link {
+  border: 0;
+  background: transparent;
+  color: var(--accent-dark);
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
-.condition-history-modal::backdrop {
+.condition-history-backdrop {
+  position: fixed;
+  inset: 0;
   background: rgba(15, 23, 42, 0.35);
+  z-index: 70;
+}
+
+.condition-history-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(440px, 100vw);
+  background: #ffffff;
+  border-left: 1px solid var(--border);
+  box-shadow: -8px 0 28px rgba(15, 23, 42, 0.2);
+  padding: 18px;
+  z-index: 80;
+  transform: translateX(100%);
+  transition: transform 180ms ease;
+  overflow-y: auto;
+}
+
+.condition-history-drawer.is-open {
+  transform: translateX(0);
 }
 
 .condition-history-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+}
+
+.condition-history-equipment {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .condition-history-list {
   list-style: none;
-  margin: 12px 0 0;
+  margin: 14px 0 0;
   padding: 0;
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
-.condition-history-list li {
+.condition-history-entry {
   background: #f7f9ff;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px 10px;
+  border-radius: 10px;
+  padding: 10px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.condition-history-entry-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.condition-history-entry p {
+  margin: 4px 0 0;
+}
+
+.condition-history-empty {
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  color: var(--muted);
+  background: #f7f9ff;
+}
+
+@media (max-width: 720px) {
+  .condition-history-drawer {
+    width: 100vw;
+    border-left: 0;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide a non-intrusive, read-only UI to show the condition timeline for a selected equipment item using existing move/log entries as the source.
- Allow users to open the timeline from the equipment table (condition badge or a small “View history” link) while keeping the main UI uncluttered.
- Ensure the timeline is robust to missing or older log shapes and sorts entries by the most relevant check time.

### Description
- Replaced the old condition history dialog with a right-side drawer and backdrop in `index.html` and added responsive styling in `styles.css` to match dashboard visuals and behave full-width on small screens.
- Added drawer state and handlers (`isConditionDrawerOpen`, `conditionDrawerEquipmentId`, `openConditionDrawer`, `closeConditionDrawer`) and wired UI interactions so the badge and inline `View history` link open the drawer and the drawer closes via the X button, backdrop click, or `Escape` key in `app.js`.
- Implemented condition history extraction and rendering from moves/logs: `getConditionHistoryEntries` filters by `equipmentId` and presence of `entry.condition`, sorts by `condition.checkedAt` (with `timestamp` fallback), and `renderConditionHistoryDrawer` renders entries newest-first while omitting missing sub-fields cleanly.
- Updated the equipment condition cell markup to include the clickable badge and an inline `View history` trigger, and added CSS classes for drawer, backdrop, entry layout, and small UI polish.

### Testing
- Ran `node --check app.js` to validate the modified JS syntax and it succeeded.
- Attempted a live UI smoke test by serving the app with `python -m http.server 4173` and capturing a screenshot via the Playwright script, but navigation failed with `ERR_EMPTY_RESPONSE` so no browser screenshot was produced.
- Verified that the code includes guards for empty/missing logs and will render the message `No condition checks recorded yet.` when no entries exist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69845299413c833398e3fa5bbb55cfa3)