### PR TITLE
Show current condition snapshot in equipment table and backfill from history

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -743,9 +743,24 @@ button:disabled {
   cursor: pointer;
 }
 
+.condition-badge--good {
+  background: rgba(35, 176, 125, 0.15);
+  color: var(--success);
+}
+
 .condition-badge--warn {
   background: rgba(245, 158, 11, 0.2);
   color: #9a6100;
+}
+
+.condition-badge--bad {
+  background: rgba(220, 38, 38, 0.14);
+  color: #b91c1c;
+}
+
+.condition-badge--neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
 }
 
 .condition-history-modal {


### PR DESCRIPTION
### Motivation
- Replace the uninformative dash in the Condition column with an immediate snapshot of the latest recorded condition so the table communicates equipment status without opening the history modal.
- Ensure legacy data and existing condition-history entries remain compatible by deriving and persisting a small snapshot on load and whenever a condition check is recorded.

### Description
- Added derived snapshot fields to equipment objects: `currentCondition` and `lastConditionCheckAt`, and included them in seeded defaults.
- Introduced `applyConditionSnapshot` and `getLatestConditionEntryFromMoves` helpers, updated `normalizeEquipmentConditionFields` to expose `currentCondition` and `lastConditionCheckAt`, and backfilled snapshots from the most recent history entry during state normalization.
- Updated move submit handling to call `applyConditionSnapshot` when a condition check is recorded so equipment snapshot fields are kept in sync, while still appending the full entry to history.
- Reworked table rendering (`buildEquipmentConditionCell`) to show a pill with the latest `rating` (or `Not checked`) and a subtext `Last checked: {date}` (or `—`), preserved the click behavior to open the history modal, and added CSS classes mapping ratings to colours (green/amber/red/neutral). Also accepted legacy/problem rating values (`Missing`, `Fault`) during normalization.

### Testing
- Ran a syntax check with `node --check app.js` (success).
- Served the app locally with `python -m http.server 4173` and captured a visual smoke test screenshot of the equipment table (UI smoke verification, success).
- Executed Playwright interaction scripts to validate pill text, modal opening and persistence; these were exercised but some runs timed out in this environment (flaky in CI); the visual smoke test confirmed the rendered pill and subtext behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984578e0c808333b07ca27b465a15c8)