### PR TITLE
Require condition checks before recording moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,12 @@
                     </fieldset>
                     <div class="condition-section">
                       <h4>Condition check</h4>
+                      <p
+                        id="move-condition-exempt-note"
+                        class="field-note is-hidden"
+                      >
+                        Condition check not required for this status.
+                      </p>
                       <div class="condition-grid">
                         <label>
                           Condition rating
@@ -316,8 +322,11 @@
                         Go to Admin → Edit equipment
                       </button>
                     </p>
-                    <p id="move-submit-blocked" class="field-warning">
-                      Complete the condition checklist before recording the move.
+                    <p
+                      id="move-submit-blocked"
+                      class="field-warning is-hidden"
+                    >
+                      Condition check required for this move.
                     </p>
                     <button type="submit" id="move-submit">
                       Record move

--- a/styles.css
+++ b/styles.css
@@ -625,6 +625,12 @@ tr:last-child td {
   color: #b4690e;
 }
 
+.field-note {
+  font-size: 12px;
+  color: #475467;
+  margin-top: 4px;
+}
+
 button {
   border: none;
   border-radius: 10px;


### PR DESCRIPTION
### Motivation
- Enforce that a condition check must be completed before recording a move except for explicit exempt statuses (`In service / repair`, `Quarantined`).
- Make the UI clearly communicate when a condition check is required vs. exempt and prevent saving when incomplete.
- Ensure data integrity by only creating condition records when a check is required and updating equipment snapshots accordingly.

### Description
- Added a set of exempt statuses `moveConditionExemptStatuses` and helper functions `isMoveShippingActive`, `getMoveConditionStatus`, and `isMoveConditionRequired` to determine whether a condition check is required (shipping inputs cause an effective `In transit` status).
- Updated move validation in `validateMoveConditionChecklist` to disable the `Record move` button when a required condition check is incomplete and to show/-hide the inline blocked message `#move-submit-blocked` and the exempt note `#move-condition-exempt-note` accordingly.
- Modified the submit handler `handleMoveSubmit` to require checklist validation for required moves and to only create/apply a condition record when `isMoveConditionRequired(item)` returns true.
- UI changes: added an exempt-status note to the move form (`index.html`) and added styling for `.field-note` in `styles.css`; added an event listener to `moveStatus` to trigger re-validation on status change and wired shipping status override to trigger validation.

### Testing
- Started a local HTTP server with `python -m http.server` and exercised the UI with a headless browser script (Playwright) to load the move form and capture a screenshot; the server started and a screenshot artifact was produced.
- Ran the app manually by refreshing UI flows via `refreshUI` paths (form syncs, status/shipping interactions) while iterating; no automated unit tests exist for this codebase and no test failures were reported during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897ddb13a8833394d1c58a4530aaec)