### PR TITLE
Add toast feedback and row highlight for move logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,6 +742,13 @@
       <ul id="condition-history-list" class="condition-history-list"></ul>
     </dialog>
 
+    <div
+      id="toast-container"
+      class="toast-container"
+      aria-live="polite"
+      aria-atomic="true"
+    ></div>
+
     <script src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -803,3 +803,58 @@ button:disabled {
   font-size: 12px;
   color: var(--muted);
 }
+
+.toast-container {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  display: grid;
+  gap: 10px;
+  z-index: 999;
+  max-width: min(320px, 90vw);
+}
+
+.toast {
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 24px rgba(27, 31, 42, 0.12);
+  font-size: 13px;
+  color: var(--ink);
+}
+
+.toast--success {
+  border-color: rgba(35, 176, 125, 0.4);
+  background: rgba(35, 176, 125, 0.08);
+}
+
+.toast--error {
+  border-color: rgba(180, 35, 24, 0.4);
+  background: rgba(180, 35, 24, 0.08);
+}
+
+.toast--info {
+  border-color: rgba(75, 110, 245, 0.4);
+  background: rgba(75, 110, 245, 0.08);
+}
+
+.equipment-row-highlight td {
+  background: rgba(75, 110, 245, 0.12);
+}
+
+.equipment-row-highlight {
+  animation: rowHighlightPulse 1.6s ease-in-out;
+}
+
+@keyframes rowHighlightPulse {
+  0%,
+  100% {
+    background: transparent;
+  }
+  50% {
+    background: rgba(75, 110, 245, 0.1);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide clear, lightweight user feedback when the user logs moves, including success and error toasts and inline guidance when condition checks are missing. 
- Prevent duplicate submissions by disabling the submit button while a save is in progress. 
- Give a visual confirmation in the equipment table by scrolling to and briefly highlighting the moved row so users can immediately see the change.

### Description
- Added a toast container to `index.html` and lightweight CSS in `styles.css` for `toast`, `toast--success`, `toast--error`, `toast--info`, and the row highlight animation.
- Implemented `showToast(message, type)` in `app.js` and wired `toastContainer` into the `elements` map to support success/error/info toasts.
- Added saving state helpers: `isMoveSaving`, `setMoveSubmitSaving(isSaving)`, and `moveSubmitDefaultLabel` to change the button label to `Saving...` and disable it while saving.
- Implemented `resetMoveForm()` to clear move inputs after a successful save and `highlightEquipmentRow(equipmentId)` which scrolls to and pulses the matching table row; updated `renderTable()` to add `data-equipment-id` to each equipment row.
- Updated `handleMoveSubmit(event)` to check `isMoveSaving`, wrap save logic in `try/catch`, show an error toast on validation failure (`showToast("Move not recorded: complete the condition check.", "error")`), show a success toast on save, reset the form, refresh UI, scroll/highlight the moved row, and log unexpected errors to the console with a toast `Something went wrong while recording the move.`

### Testing
- Performed an automated smoke test by serving the app locally and launching a Playwright script that opened the page and captured a screenshot; the page loaded and a screenshot artifact was produced successfully. 
- No unit tests were added; the changes were validated with the smoke test above and a static code inspection of `app.js`, `index.html`, and `styles.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698982d89fe483338f6446edfc42033c)