### PR TITLE
Add Inbound panel and mark-received flow for incoming moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,38 @@
                 </div>
               </section>
             </div>
+
+            <section class="card inbound-card">
+              <div class="card-header">
+                <div>
+                  <h2>Inbound</h2>
+                  <p>Incoming moves that are awaiting receipt.</p>
+                </div>
+                <div class="filters">
+                  <div class="filter">
+                    <label for="inbound-location-filter">Destination</label>
+                    <select id="inbound-location-filter"></select>
+                  </div>
+                </div>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Equipment</th>
+                      <th>From → To</th>
+                      <th>Shipped</th>
+                      <th>ETA</th>
+                      <th>Courier</th>
+                      <th>Tracking</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="inbound-table-body"></tbody>
+                </table>
+              </div>
+              <p id="inbound-count" class="inbound-count"></p>
+            </section>
           </section>
         </div>
 

--- a/styles.css
+++ b/styles.css
@@ -716,6 +716,12 @@ button:disabled {
   color: var(--muted);
 }
 
+.inbound-count {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .tag {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Allow receiving offices to see incoming moves filtered by destination and act on them so inbound shipments are acknowledged and equipment locations are updated.
- Preserve audit history by adding receipt metadata rather than removing move entries.

### Description
- Add an Inbound panel to the Operations view in `index.html` with a `#inbound-location-filter`, `#inbound-table-body` and `#inbound-count` showing equipment, route, shipped date, ETA, courier, tracking and actions. 
- Wire new DOM elements into `app.js` (`elements.inboundLocationFilter`, `elements.inboundTableBody`, `elements.inboundCount`) and add `renderInboundLocationOptions`, `getInboundMoves`, and `renderInboundView` to produce the filtered inbound list.
- Extend history normalization to include `receivedAt` in `normalizeHistoryEntry` so received timestamps are captured as first-class data on move entries.
- Add helper functions `getMoveReceivedAt` and `hasReceivedLogAfterMove`, update shipping / in-transit logic (`isShippingActive` and related checks) to consider `receivedAt` and explicit received logs when deciding whether a move is still active.
- Update move recording (`logHistory` on move submit) to set `receivedAt: ""` for new moves with shipping, and update `handleMarkReceived` to: set `moveEntry.receivedAt`, set `moveEntry.shipping.deliveredAt`, update equipment `location` and `lastMoved`, and write a `received` history entry via `logHistory` (additive audit trail). 
- Add click handlers so the Inbound table's "Mark received" buttons call `handleMarkReceived`, and add a small style for `.inbound-count` in `styles.css`.

### Testing
- Ran a headless browser script using Playwright to load the app and capture the new Inbound view; the run succeeded and generated a screenshot artifact (`artifacts/inbound-view.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989857061188333a258ddaba1c0fc02)