### PR TITLE
Audit-safe moves log: soft-delete, correction entries, and show-deleted UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
                   <div class="history-header">
                     <h3>Recent moves</h3>
                     <button id="clear-history" type="button">
-                      Clear history
+                      Archive history
                     </button>
                   </div>
                   <ul id="history-list"></ul>
@@ -432,6 +432,12 @@
                   <div class="filter">
                     <label for="moves-type-filter">Type</label>
                     <select id="moves-type-filter"></select>
+                  </div>
+                  <div class="filter">
+                    <label class="checkbox-field">
+                      Show deleted
+                      <input id="moves-show-deleted" type="checkbox" />
+                    </label>
                   </div>
                 </div>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,40 @@ textarea:focus {
   color: var(--muted);
 }
 
+.moves-row--deleted {
+  opacity: 0.6;
+}
+
+.moves-note-meta {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.moves-note-meta--deleted {
+  color: #b42318;
+}
+
+.moves-corrections {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.moves-corrections p {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.moves-corrections ul {
+  margin: 4px 0 0;
+  padding-left: 18px;
+}
+
 .shipping-details-card {
   background: #f7f9ff;
   border: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- Enforce audit integrity for move/log entries by preventing irreversible per-entry deletion in non-admin contexts and by introducing an auditable correction flow.
- Make deleted entries recoverable and hidden by default while providing an admin-controlled way to archive history and view deleted records.

### Description
- Added a new `correction` history type and parsing support, and surface it in `moveTypeOptions` and `normalizeHistoryType` in `app.js`.
- Implemented soft-delete metadata fields (`deletedAt`, `deletedBy`, `deleteReason`) and replaced destructive delete logic with a soft-delete flow that is admin-only; the delete action label is updated to "Soft delete" and bulk-archive (previously "Clear history") now archives entries with a reason.
- Added a correction workflow (`Add correction`) that creates new `correction` entries referencing the original entry id (via `correctionOf`) without mutating the original entry, and record corrections via `logHistory`.
- Updated Moves UI to filter out deleted entries by default, added a "Show deleted" checkbox to toggle visibility, render corrections associated with entries, and display deleted metadata; changes touch `app.js`, `index.html`, and `styles.css` (styling for deleted rows, correction/meta blocks).

### Testing
- Started a local web server with `python -m http.server 8000` to exercise the UI (server started successfully). 
- Attempted an automated UI smoke test to capture the Moves view screenshot using Playwright, but the Playwright run timed out (no screenshot produced).
- Performed automated code inspection commands (searches) to verify new symbols and hooks are present and wired to the UI (no unit test harness available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698987fe9a5c83338c064b345f0a22ba)