### PR TITLE
Add local admin passcode gate and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,10 +59,15 @@
             Admin
           </button>
         </nav>
-        <label class="admin-toggle" for="admin-mode-toggle">
-          <input id="admin-mode-toggle" type="checkbox" />
-          <span>Admin mode</span>
-        </label>
+        <div class="admin-controls">
+          <label class="admin-toggle" for="admin-mode-toggle">
+            <input id="admin-mode-toggle" type="checkbox" />
+            <span>Admin mode</span>
+          </label>
+          <p class="admin-toggle-note">
+            Admin mode is a local browser control, not enterprise authentication.
+          </p>
+        </div>
       </div>
 
       <main>
@@ -471,6 +476,36 @@
               <p>Use these tools to add or update equipment records.</p>
 
               <div class="console">
+                <form id="admin-passcode-settings" class="panel">
+                  <h3>Admin passcode</h3>
+                  <p class="panel-hint">
+                    This passcode is stored only in this browser (not enterprise
+                    authentication). Clearing local storage resets it.
+                  </p>
+                  <label>
+                    Current passcode
+                    <input id="admin-passcode-current" type="password" />
+                  </label>
+                  <label>
+                    New passcode
+                    <input id="admin-passcode-update" type="password" />
+                  </label>
+                  <label>
+                    Confirm new passcode
+                    <input id="admin-passcode-update-confirm" type="password" />
+                  </label>
+                  <p
+                    id="admin-passcode-update-error"
+                    class="field-error is-hidden"
+                  ></p>
+                  <p
+                    id="admin-passcode-update-success"
+                    class="field-success is-hidden"
+                  >
+                    Passcode updated.
+                  </p>
+                  <button type="submit">Update passcode</button>
+                </form>
                 <form id="add-equipment-form" class="panel">
                   <h3>Add new equipment</h3>
                   <label>
@@ -786,6 +821,44 @@
       aria-live="polite"
       aria-atomic="true"
     ></div>
+
+    <dialog id="admin-passcode-dialog" class="admin-passcode-dialog">
+      <form id="admin-passcode-form" class="panel" novalidate>
+        <h3 id="admin-passcode-title">Enable Admin mode</h3>
+        <p class="panel-hint" id="admin-passcode-hint">
+          Enter the local browser passcode to unlock Admin mode.
+        </p>
+        <div id="admin-passcode-verify">
+          <label>
+            Passcode
+            <input id="admin-passcode-input" type="password" />
+          </label>
+        </div>
+        <div id="admin-passcode-setup" class="is-hidden">
+          <label>
+            Set a new passcode
+            <input id="admin-passcode-new" type="password" />
+          </label>
+          <label>
+            Confirm passcode
+            <input id="admin-passcode-confirm" type="password" />
+          </label>
+        </div>
+        <p id="admin-passcode-error" class="field-error is-hidden"></p>
+        <div class="dialog-actions">
+          <button
+            type="button"
+            class="button-secondary"
+            id="admin-passcode-cancel"
+          >
+            Cancel
+          </button>
+          <button type="submit" id="admin-passcode-submit">
+            Enable Admin mode
+          </button>
+        </div>
+      </form>
+    </dialog>
 
     <script src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,14 @@ h1 {
   margin-bottom: 24px;
 }
 
+.admin-controls {
+  display: grid;
+  gap: 4px;
+  justify-items: end;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .tabs {
   display: inline-flex;
   gap: 8px;
@@ -123,6 +131,11 @@ h1 {
 .admin-toggle input {
   margin: 0;
   accent-color: var(--accent);
+}
+
+.admin-toggle-note {
+  margin: 0;
+  font-size: 11px;
 }
 
 .tab-panel {
@@ -659,6 +672,11 @@ tr:last-child td {
   color: #b4690e;
 }
 
+.field-success {
+  font-size: 12px;
+  color: var(--success);
+}
+
 .field-note {
   font-size: 12px;
   color: #475467;
@@ -696,6 +714,33 @@ button:disabled {
 
 .link-button:hover {
   color: var(--accent);
+}
+
+.admin-passcode-dialog {
+  border: none;
+  border-radius: 18px;
+  padding: 0;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+  max-width: 420px;
+  width: min(90vw, 420px);
+}
+
+.admin-passcode-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.admin-passcode-dialog .panel {
+  border: none;
+  border-radius: 18px;
+  background: var(--card);
+  padding: 20px;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
 }
 
 .copy-checklist {


### PR DESCRIPTION
### Motivation
- Provide a lightweight, local-browser role gate for Admin mode so destructive/admin-only actions are protected without backend auth.
- Make it clear in the UI that this is a browser-local control and not enterprise authentication.
- Maintain existing behavior where operations users can log moves/mark received/view logs while admin users can add/edit equipment, import, soft-delete logs, and change settings.

### Description
- Add UI: admin toggle explanatory copy, an Admin passcode settings panel in the Admin view, and a modal dialog to set/verify the passcode (`index.html`).
- Persist passcode in `localStorage` under `equipmentTrackerAdminPasscode` and expose helper functions to read/save the record; use SHA-256 hashing via `crypto.subtle` when available (`app.js`).
- Require passcode to enable Admin mode and gate programmatic jumps to the Admin tab via `requestAdminModeEnable`/pending action flow, so enabling Admin or navigating to admin tools opens the passcode dialog if not already unlocked (`app.js`).
- Keep Admin tab and destructive actions hidden unless Admin mode is enabled; keep explanatory UI text that this is a local browser control and not enterprise auth (`index.html`, `styles.css`).
- Add styles for the admin controls, passcode dialog and small success/error feedback (`styles.css`).

### Testing
- Launched a local static server and loaded the app to render the modified UI, which succeeded and produced a screenshot artifact (`python -m http.server` + Playwright script); rendering/screenshot succeeded.
- Verified the Admin passcode dialog appears when toggling Admin mode and that the Admin tab and destructive actions are hidden until passcode is set and verified; checks completed visually via the rendered page (Playwright screenshot).
- Committed changes and confirmed files modified: `app.js`, `index.html`, `styles.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69898aa53dfc8333a519933a44a29628)