### PR TITLE
Remove Inbound panel and consolidate receipt workflow into Moves log

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,37 +379,6 @@
               </section>
             </div>
 
-            <section class="card inbound-card">
-              <div class="card-header">
-                <div>
-                  <h2>Inbound</h2>
-                  <p>Incoming moves that are awaiting receipt.</p>
-                </div>
-                <div class="filters">
-                  <div class="filter">
-                    <label for="inbound-location-filter">Destination</label>
-                    <select id="inbound-location-filter"></select>
-                  </div>
-                </div>
-              </div>
-              <div class="table-wrapper">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Equipment</th>
-                      <th>From → To</th>
-                      <th>Shipped</th>
-                      <th>ETA</th>
-                      <th>Courier</th>
-                      <th>Tracking</th>
-                      <th>Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody id="inbound-table-body"></tbody>
-                </table>
-              </div>
-              <p id="inbound-count" class="inbound-count"></p>
-            </section>
           </section>
         </div>
 
@@ -439,9 +408,19 @@
                     <select id="moves-type-filter"></select>
                   </div>
                   <div class="filter">
+                    <label for="moves-destination-filter">Destination</label>
+                    <select id="moves-destination-filter"></select>
+                  </div>
+                  <div class="filter">
                     <label class="checkbox-field">
                       Show deleted
                       <input id="moves-show-deleted" type="checkbox" />
+                    </label>
+                  </div>
+                  <div class="filter">
+                    <label class="checkbox-field">
+                      Requiring receipt
+                      <input id="moves-receipt-only" type="checkbox" />
                     </label>
                   </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -795,12 +795,6 @@ button:disabled {
   color: var(--muted);
 }
 
-.inbound-count {
-  margin: 12px 0 0;
-  font-size: 12px;
-  color: var(--muted);
-}
-
 .tag {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Consolidate inbound receipt handling into the Moves log so inbound UI/logic is unified and simpler.
- Provide destination filtering and a "Requiring receipt" view so staff can find and mark incoming shipments from the Moves view.
- Ensure marking received updates move shipping metadata, equipment location/status and persists immediately.

### Description
- Removed the Inbound panel from `index.html` and cleaned up related CSS selectors so inbound UI no longer appears on the Operations page.
- Added new Moves filters in the UI: a `Destination` dropdown (`moves-destination-filter`) and a `Requiring receipt` checkbox (`moves-receipt-only`) in `index.html` and wired them into `app.js`.
- Extended shipping data handling by adding `receivedAt`/`receivedBy` fields to `normalizeShippingDetails` and updated `getMoveReceivedAt` to consider them.
- Implemented helper functions `hasShippingReceiptDetails`, `isMoveAwaitingReceipt`, and `getReceiptIndicator`, and updated `getFilteredMoves` and `renderMovesView` to support destination filtering, receipt-only filtering, and a new small "Receipt" column showing received/awaiting/— states.
- Reworked `handleMarkReceived` to set `move.shipping.receivedAt`, `move.shipping.receivedBy`, update the equipment `location`/`currentLocation` and a sensible post-receipt `status` (uses `shipping.postReceiptStatus` if present, otherwise defaults to `Available`), log a `received` history entry, persist state to `localStorage` and show a toast confirmation.
- Removed inbound-specific rendering and event handlers from `app.js` (moves rendering now covers receipt actions); bound the new filters to `renderMovesView`.

### Testing
- Started a local static server with `python -m http.server 8000` and verified `index.html` is served successfully (smoke check using `curl`).
- Ran a headless browser script (Playwright) to load the app and capture a screenshot of the Moves view to verify the new filters and columns render; initial run timed out but a subsequent run produced a page screenshot successfully.
- Performed automated text searches (`rg`) on source files to confirm inbound UI identifiers were removed and new moves filter IDs were added; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69898d5a6ff88333b9ee9dbae991b1c4)