### PR TITLE
Prevent admin dialog from closing the tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,17 @@ const TAB_STORAGE_KEY = "equipmentTrackerActiveTab";
 const ADMIN_MODE_KEY = "equipmentTrackerAdminMode";
 const ADMIN_PASSCODE_KEY = "equipmentTrackerAdminPasscode";
 
+const disableClose = () => {};
+window.close = disableClose;
+self.close = disableClose;
+window.addEventListener("beforeunload", (event) => {
+  const adminDialog = document.querySelector("#admin-passcode-dialog");
+  if (adminDialog?.open) {
+    event.preventDefault();
+    event.returnValue = "";
+  }
+});
+
 const physicalLocations = [
   "Perth",
   "Melbourne",


### PR DESCRIPTION
### Motivation
- Prevent accidental tab/window closing or navigation during the Admin passcode flow so that opening the admin dialog cannot cause the app to be closed or navigated away from.

### Description
- Add a close-prevention shim that overrides `window.close` and `self.close` to no-ops and register a `beforeunload` handler that blocks unloads while the `#admin-passcode-dialog` is open; no direct `close()` or `location` redirect calls were present in the codebase so none were removed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989936b2bb4833393201e29166e6467)