### PR TITLE
Prevent navigation/unload prompts during Admin passcode flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,17 +3,6 @@ const TAB_STORAGE_KEY = "equipmentTrackerActiveTab";
 const ADMIN_MODE_KEY = "equipmentTrackerAdminMode";
 const ADMIN_PASSCODE_KEY = "equipmentTrackerAdminPasscode";
 
-const disableClose = () => {};
-window.close = disableClose;
-self.close = disableClose;
-window.addEventListener("beforeunload", (event) => {
-  const adminDialog = document.querySelector("#admin-passcode-dialog");
-  if (adminDialog?.open) {
-    event.preventDefault();
-    event.returnValue = "";
-  }
-});
-
 const physicalLocations = [
   "Perth",
   "Melbourne",
@@ -1561,6 +1550,7 @@ function setAdminPasscodeSettingsError(message) {
 
 async function handleAdminPasscodeFormSubmit(event) {
   event.preventDefault();
+  event.stopPropagation();
   resetAdminPasscodeSettingsStatus();
   setAdminPasscodeDialogError("");
   const mode = elements.adminPasscodeDialog?.dataset.mode ?? "verify";
@@ -5696,7 +5686,9 @@ if (elements.adminPasscodeForm) {
 }
 
 if (elements.adminPasscodeCancel) {
-  elements.adminPasscodeCancel.addEventListener("click", () => {
+  elements.adminPasscodeCancel.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
     closeAdminPasscodeDialog();
   });
 }


### PR DESCRIPTION
### Motivation
- The admin passcode flow could trigger browser navigation/unload prompts ("Leave site?") due to event propagation and an unload/close shim, so the dialog interactions need to avoid causing navigation.

### Description
- Remove the noop `window.close`/`self.close` shims and the `beforeunload` handler that blocked unload while the admin dialog was open in `app.js`.
- In `handleAdminPasscodeFormSubmit` add `event.preventDefault()` and `event.stopPropagation()` to stop the form submit from propagating and triggering navigation.
- Update the admin passcode Cancel button handler to call `event.preventDefault()` and `event.stopPropagation()` before closing the dialog.
- Changes are limited to `app.js` to avoid blocking unload or causing navigation from admin toggle/passcode handlers.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989956d174c8333aac2a9d7f905eb7f)