### PR TITLE
Gate debug tripwire and restore admin passcode form submission

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,13 @@ const ADMIN_MODE_KEY = "equipmentTrackerAdminMode";
 const ADMIN_PASSCODE_KEY = "equipmentTrackerAdminPasscode";
 // === PCTE DEBUG TRIPWIRE v2 ===
 (function tripwireV2() {
+  const tripwireEnabled =
+    new URLSearchParams(location.search).has("tripwire") ||
+    localStorage.getItem("pcteTripwire") === "true";
+  if (!tripwireEnabled) {
+    return;
+  }
+
   const blockClose = function () {
     console.warn("Blocked window.close()", new Error("close stack").stack);
   };
@@ -18,30 +25,6 @@ const ADMIN_PASSCODE_KEY = "equipmentTrackerAdminPasscode";
   window.addEventListener("unload", () => {
     console.warn("Lifecycle: unload", location.href);
   });
-
-  document.addEventListener(
-    "submit",
-    (e) => {
-      console.warn("Form submit blocked:", e.target);
-      e.preventDefault();
-      e.stopPropagation();
-      return false;
-    },
-    true
-  );
-
-  document.addEventListener(
-    "click",
-    (e) => {
-      const a = e.target && e.target.closest ? e.target.closest("a") : null;
-      if (a && a.getAttribute("href") && a.getAttribute("href") !== "#") {
-        console.warn("Link navigation blocked:", a.getAttribute("href"), a);
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    },
-    true
-  );
 })();
 // === /PCTE DEBUG TRIPWIRE v2 ===
 


### PR DESCRIPTION
### Motivation
- The existing debug tripwire installed global capture-phase handlers that were preventing legitimate form submits and link navigation (notably breaking the admin passcode flow). 
- The tripwire should be usable for debugging without interfering with normal app behaviour unless explicitly enabled.

### Description
- Added a guard that only enables the tripwire when `?tripwire` is present in the URL or when `localStorage.getItem("pcteTripwire") === "true"` and returns early otherwise. 
- Removed the global capture-phase `submit` and `click` blockers from the tripwire, leaving only `window.close` interception and lifecycle logging (`pagehide`/`unload`) when the tripwire is active. 
- Confirmed the admin passcode form (`#admin-passcode-form`) and handler (`handleAdminPasscodeFormSubmit`) remain wired so submit works normally and the dialog close/admin mode enable path is preserved.

### Testing
- Started a local static server with `python3 -m http.server 4173` which ran successfully. 
- Executed a Playwright automation that exercised the admin passcode setup flow and it passed with results showing the dialog opened in `setup` mode, the dialog was closed after submit, and admin mode toggle became checked. 
- Captured a screenshot of the successful admin passcode flow at `artifacts/admin-passcode-flow.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa7742864833398da7e9c27148d3a)