### PR TITLE
Refocus Operations console on move logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,11 +173,9 @@
 
               <section class="card">
                 <h2>Console</h2>
-                <p>
-                  Use the console to log moves or record calibration updates.
-                </p>
+                <p>Use the console to log equipment moves.</p>
 
-                <div class="console">
+                <div class="console console--operations">
                   <form id="move-form" class="panel">
                     <h3>Log a move</h3>
                     <label>
@@ -337,34 +335,6 @@
                       Record move
                     </button>
                   </form>
-
-                  <form id="calibration-form" class="panel">
-                    <h3>Record calibration</h3>
-                    <label>
-                      Equipment
-                      <select id="calibration-equipment"></select>
-                    </label>
-                    <label>
-                      Calibration date
-                      <input id="calibration-date" type="date" />
-                    </label>
-                    <label>
-                      Interval months (optional override)
-                      <input
-                        id="calibration-interval"
-                        type="number"
-                        min="1"
-                        step="1"
-                        placeholder="e.g. 18"
-                      />
-                    </label>
-                    <label class="checkbox-field">
-                      Calibration required
-                      <input id="calibration-required" type="checkbox" />
-                    </label>
-                    <button type="submit">Save calibration</button>
-                  </form>
-
                 </div>
 
                 <div class="history">
@@ -485,6 +455,34 @@
                   </p>
                   <button type="submit">Update passcode</button>
                 </form>
+
+                <form id="calibration-form" class="panel">
+                  <h3>Record calibration</h3>
+                  <label>
+                    Equipment
+                    <select id="calibration-equipment"></select>
+                  </label>
+                  <label>
+                    Calibration date
+                    <input id="calibration-date" type="date" />
+                  </label>
+                  <label>
+                    Interval months (optional override)
+                    <input
+                      id="calibration-interval"
+                      type="number"
+                      min="1"
+                      step="1"
+                      placeholder="e.g. 18"
+                    />
+                  </label>
+                  <label class="checkbox-field">
+                    Calibration required
+                    <input id="calibration-required" type="checkbox" />
+                  </label>
+                  <button type="submit">Save calibration</button>
+                </form>
+
                 <form id="add-equipment-form" class="panel">
                   <h3>Add new equipment</h3>
                   <label>

--- a/styles.css
+++ b/styles.css
@@ -481,6 +481,17 @@ tr:last-child td {
   margin: 16px 0 24px;
 }
 
+.console--operations {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.console--operations #move-form {
+  gap: 14px;
+  max-height: min(78vh, 1100px);
+  overflow-y: auto;
+  align-content: start;
+}
+
 .panel {
   border: 1px solid var(--border);
   padding: 16px;


### PR DESCRIPTION
### Motivation
- Make the Operations Console single-purpose for logging equipment moves and remove the calibration UI from that view to reduce clutter and improve usability.
- Surface calibration management under Administration where admin workflows already live, preserving existing validations and behavior.

### Description
- Updated `index.html` (Operations Console card): changed helper text, removed the `Record calibration` form from the Operations Console, and added `class="console console--operations"` so the Operations console uses a dedicated modifier. (Section: Operations Console / `#move-form`)
- Updated `index.html` (Admin Console card): reinserted the `Record calibration` form into the Admin console so calibration is accessible from Admin; preserved original field IDs and markup to keep behavior and wiring intact. (Section: Admin Console / `#calibration-form`)
- Updated `styles.css`: added `.console--operations` to force a single full-width column for the Operations console and added scrolling/spacing rules for `#move-form` (`gap`, `max-height`, `overflow-y`, `align-content`) to avoid cramped controls and allow vertical scrolling if the form exceeds the viewport.
- No changes were made to the underlying data model or storage keys; this is a UI relocation only and existing event handlers/IDs remain unchanged.

### Testing
- Ran a syntax check with `node --check app.js`, which completed successfully.
- Ran unit tests with `node --test tests/applyCorrectionsToMoves.test.js`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac9acea6483338803bd5037c198c6)