### PR TITLE
Expand equipment CSV import fields and robust date parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,7 +712,7 @@
                   <h3>Import equipment</h3>
                   <p class="panel-hint">
                     Upload a CSV to bulk add equipment. Existing items are never
-                    removed.
+                    removed. Dates accepted: yyyy-mm-dd or dd/mm/yyyy. Excel serial dates also supported.
                   </p>
                   <div class="panel-actions">
                     <button type="button" id="import-template-button">


### PR DESCRIPTION
### Motivation
- The CSV importer lacked headers and parsing to populate newer equipment fields (subscription and condition/checklist fields) and did not reliably parse mixed date formats or Excel serial dates. 
- Improve user feedback when Excel `#######` placeholders appear and enforce required-field validation for safer bulk imports.

### Description
- Expanded `equipmentImportTemplateHeaders` and the generated template (`buildEquipmentImportTemplate`) to include `subscriptionRequired`, `subscriptionRenewalDate`, `conditionContentsChecklist`, and `conditionFunctionalChecklist`, and updated sample rows to show ISO, AU-style, dash-style and Excel-serial examples. 
- Reworked date parsing by adding `parseFlexibleDateToISO(value)`, `excelSerialToISO(n)`, `parseImportDateField(...)`, `parseImportBoolean(...)` and treating `#######` as an invalid placeholder that produces a warning; `parseFlexibleDate` now delegates to the ISO normalizer. 
- Updated `parseEquipmentImportRows` to read and validate the new headers, require `name`, `model`, and `serialNumber`, validate `lastCalibrationDate` when `calibrationRequired=true`, and validate `subscriptionRenewalDate` when `subscriptionRequired=true`, while collecting row issues. 
- Changed import row validity to `isValid: issues.length === 0` and kept duplicate detection logic (including duplicates within the same file) via existing `applyDuplicateHandling`. 
- Mapped parsed checklist fields into created equipment objects so `conditionReference` uses imported `contentsChecklist` and `functionalChecklist` values instead of empty defaults. 
- Updated the import panel hint copy in `index.html` to state accepted date formats and mention Excel serial dates.

### Testing
- Ran unit tests with `node --test` and all tests passed (2 tests). 
- Checked syntax with `node --check app.js` with no errors. 
- Attempted a headless UI screenshot via Playwright to visually verify the import panel, but the browser run failed to load the local page (`ERR_EMPTY_RESPONSE`), so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699412d8d3608333b853467eb9c77e38)