### PR TITLE
Render hero build version from single main.js constant

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,8 @@ import { createRepository } from "./repository/index.js";
 import { createLocalStorageStorageAdapter, hasConditionMigrationFlag, loadActiveTab, readStoredAppState, saveActiveTab, setConditionMigrationFlag } from "./storage.js";
 
 // === BUILD VERSION ===
-// Increment this on each production deployment.
-export const BUILD_VERSION = "2026.02.17.01";
+// Update this string on each deployment.
+const BUILD_VERSION = "2026-02-17.v01";
 
 const SCHEMA_VERSION = 2;
 const physicalLocations = [


### PR DESCRIPTION
### Motivation
- Centralize the build identifier so the hero heading renders a single, deployment-formatted build string (`YYYY-MM-DD.vNN`) defined in one place and visible in the UI.

### Description
- Define `const BUILD_VERSION = "2026-02-17.v01"` at the top of `src/main.js` (replacing the previous exported value) and rely on the existing `renderBuildVersion()` helper which is called during startup to populate the `<span id="build-version"></span>` in `index.html`.

### Testing
- Verified references with `rg -n "BUILD_VERSION|build-version|Build:"` (found expected locations), served the app with `python -m http.server 4173` and validated the rendered build string via a Playwright screenshot (success), and committed the change with `git commit` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69942dcd888c8333b77d5996710d516d)