### PR TITLE
Add minimal Supabase Auth login/logout UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,6 +423,35 @@
             aria-labelledby="tab-button-admin"
           >
             <section class="card">
+              <section class="panel" aria-label="Supabase authentication">
+                <h3>Login</h3>
+                <label for="auth-email">
+                  Email
+                  <input id="auth-email" type="email" autocomplete="email" />
+                </label>
+                <label for="auth-password">
+                  Password
+                  <input
+                    id="auth-password"
+                    type="password"
+                    autocomplete="current-password"
+                  />
+                </label>
+                <div class="panel-actions">
+                  <button type="button" id="auth-login-button">Login</button>
+                  <button
+                    type="button"
+                    id="auth-logout-button"
+                    class="button-secondary"
+                  >
+                    Logout
+                  </button>
+                </div>
+                <p id="auth-status" class="panel-hint" aria-live="polite">
+                  Not logged in
+                </p>
+              </section>
+
               <h2>Administration</h2>
               <p>Use these tools to add or update equipment records.</p>
 


### PR DESCRIPTION
### Motivation
- Provide a minimal authentication surface so the app can sign users in via Supabase Auth and show current session state in the Admin UI.
- Keep the integration lightweight and non-invasive so existing move logic and local passcode/admin-mode behavior remain unchanged.
- Use Supabase session handling only and avoid storing credentials or sessions manually in `localStorage`.

### Description
- Added a compact login panel to the top of the Admin tab in `index.html` containing email input (`#auth-email`), password input (`#auth-password`), login button (`#auth-login-button`), logout button (`#auth-logout-button`) and status text (`#auth-status`).
- Imported the shared Supabase client in `src/main.js` with `import { supabase } from "./supabaseClient.js"` and wired new UI element references into the `elements` map.
- Implemented `signInWithPassword(email, password)`, `signOut()`, `initializeAuthUI()`, `updateAuthUI()` and `setAuthStatus()` in `src/main.js` that use `supabase.auth.signInWithPassword()` and `supabase.auth.getSession()` and update the UI to show `Logged in as {email}` or `Not logged in`.
- Wired event handlers for login/logout button clicks and Enter-on-password, subscribed to `supabase.auth.onAuthStateChange(...)`, and ensured the changes do not modify any move logic or manual localStorage session handling.

### Testing
- Ran the repository tests with `node --test tests/*.test.js` and all tests passed (2 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ff78214483338a81c400ccb4eec7)