### PR TITLE
Hardcode Supabase publishable key and add initialization log

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,6 +1,8 @@
 import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
 
-const SUPABASE_URL = "https://eugdravtvewpnwkkpkzl.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "SUPABASE_PUBLISHABLE_KEY";
+export const supabase = createClient(
+  "https://eugdravtvewpnwkkpkzl.supabase.co",
+  "sb_publishable_n2xhgXcQ1K2cEnk8g_JXsA_UKKBLhUH"
+);
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+console.log("Supabase initialised:", supabase);


### PR DESCRIPTION
### Motivation
- Ensure the app initializes Supabase with the correct publishable key and not via environment variables, legacy anon keys, or service_role keys to fix authentication issues.
- Add immediate runtime visibility of the client so initialization problems are easier to debug.

### Description
- Replaced the previous constant-based initialization with a direct `createClient(...)` call using the CDN import and the exact project URL and publishable key: `"https://eugdravtvewpnwkkpkzl.supabase.co"` and `"sb_publishable_n2xhgXcQ1K2cEnk8g_JXsA_UKKBLhUH"`.
- Removed the placeholder `SUPABASE_PUBLISHABLE_KEY` and any environment variable references and ensured the key is a single double-quoted string with no backticks, line breaks, or extra spaces.
- Added `console.log("Supabase initialised:", supabase);` immediately after client creation.
- Did not modify any other application logic.

### Testing
- Ran `sed -n '1,200p' src/supabaseClient.js` to verify the updated file contents and observed the expected `createClient` call with the correct key, which succeeded.
- Ran `git status --short` to confirm the file was staged/modified, which succeeded.
- Committed the change and the commit operation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69980d0fb088833380635fb25e916419)