### PR TITLE
Add Admin test panel for Supabase move_create edge function

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,6 +452,18 @@
                 </p>
               </section>
 
+              <section class="panel" aria-label="Supabase move create test">
+                <h3>move_create test</h3>
+                <div class="panel-actions">
+                  <button type="button" id="auth-test-move-create-button">
+                    Test move_create (Supabase)
+                  </button>
+                </div>
+                <pre id="auth-test-move-create-output" class="panel-hint">
+Not run yet
+                </pre>
+              </section>
+
               <h2>Administration</h2>
               <p>Use these tools to add or update equipment records.</p>
 


### PR DESCRIPTION
### Motivation
- Provide a small, standalone admin test tool to exercise the deployed Supabase Edge Function `move_create` using a real JWT-authenticated request for debugging and verification. 
- Keep the test isolated from existing app flows and localStorage logic so it cannot affect the app's normal behavior.

### Description
- Added a new test panel under the existing Supabase login panel in `index.html` that contains a button `Test move_create (Supabase)` and a `<pre id="auth-test-move-create-output">` output area.
- Added DOM hooks and a test flow in `src/main.js` which uses the existing `supabase` client to call `supabase.auth.getSession()` and then POSTs a hardcoded payload to `https://eugdravtvewpnwkkpkzl.supabase.co/functions/v1/move_create` with `Authorization: Bearer <access_token>`.
- The payload includes the requested hardcoded IDs for KIT-001, Perth, and Melbourne and the specified move details, and explicitly omits `user_id` so the function reads the user from the JWT.
- The handler pretty-prints JSON responses where possible and updates the `<pre>` output with `HTTP <status>` and the response body; no other app logic or localStorage move handling was changed and the existing `supabase` import is reused.

### Testing
- Started a local static server (`python -m http.server 4173`) and loaded the app to verify the new UI assets were served successfully.
- Ran a Playwright script to capture a screenshot of the Admin view; the first script attempt to click the admin tab timed out because the tab is hidden until admin mode is enabled (failure), then a revised script forcibly unhid the `#admin-view` and successfully produced a screenshot (success).
- Inspected the modified files and diffs to confirm the new HTML and JS were added to `index.html` and `src/main.js` and that the handler is wired to the new button (validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981595b13083338b577f8e67fbfca8)