### PR TITLE
Fix Admin login to handle Supabase sign-in responses and log errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -566,9 +566,12 @@ async function signInWithPassword(email, password) {
 
   if (error) {
     setAuthStatus(`Login failed: ${error.message}`);
+    console.error(error);
     return;
   }
 
+  const loggedInEmail = data?.user?.email ?? data?.session?.user?.email ?? "";
+  setAuthStatus(loggedInEmail ? `Logged in as ${loggedInEmail}` : "Logged in");
   updateAuthUI(data.session ?? null);
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Admin Login button reliably surfaces Supabase Auth sign-in results and logs failures for debugging.
- Use the Supabase auth response to display the authenticated user email in the UI while preserving the existing session-based flow.

### Description
- In `src/main.js` updated `signInWithPassword` to call `console.error(error)` when `supabase.auth.signInWithPassword` returns an error and to keep the existing `setAuthStatus` failure message.
- On successful sign-in the code now derives the email from `data.user.email` with a fallback to `data.session.user.email` and shows `Logged in as <email>` via `setAuthStatus`, while still calling `updateAuthUI(data.session ?? null)` to preserve session handling.
- Did not store tokens manually or change any other authentication or UI features; the file modified is `src/main.js` and no other app behavior was altered.

### Testing
- Ran the unit tests with `node --test tests/*.test.js`, and the test suite passed (2/2 tests).
- No additional automated tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fff428bfc8333b2207f87a26d1b53)