### PR TITLE
Add Admin move_receipt Supabase test panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,18 @@ Not run yet
                 </pre>
               </section>
 
+              <section class="panel" aria-label="Supabase move receipt test">
+                <h3>move_receipt test</h3>
+                <div class="panel-actions">
+                  <button type="button" id="auth-test-move-receipt-button">
+                    Test move_receipt (Supabase)
+                  </button>
+                </div>
+                <pre id="auth-test-move-receipt-output" class="panel-hint">
+Not run yet
+                </pre>
+              </section>
+
               <h2>Administration</h2>
               <p>Use these tools to add or update equipment records.</p>
 


### PR DESCRIPTION
### Motivation
- Provide a quick admin UI to exercise the Supabase `move_receipt` function analogous to the existing `move_create` test panel for debugging and integration checks.

### Description
- Added a new Admin panel in `index.html` titled `move_receipt test` with a button `Test move_receipt (Supabase)` and a `<pre id="auth-test-move-receipt-output">` output area placed directly under the existing `move_create test` panel.
- Extended `src/main.js` `elements` registry with `authTestMoveReceiptButton` and `authTestMoveReceiptOutput` and added `setMoveReceiptTestOutput(message)` to write to the new output area.
- Implemented `testMoveReceiptSupabase()` which uses the existing `supabase.auth.getSession()` call, returns `Not logged in` when no session, extracts `data.session.access_token` as the bearer token, posts the hardcoded payload to `https://eugdravtvewpnwkkpkzl.supabase.co/functions/v1/move_receipt` with `Content-Type: application/json` and `Authorization: Bearer <token>`, uses an `AbortController` with a 10s timeout, and writes outputs in the required formats (`Using token: <first 20 chars>...`, `HTTP <status>

<responseText>`, `FETCH ERROR: <message>`, or `TIMEOUT`).
- Wired the new button to call `testMoveReceiptSupabase()` on click without changing other app logic.

### Testing
- Ran `node --check src/main.js` which completed successfully.
- Served the app with `python3 -m http.server 8000` and verified the root HTML via `curl` returned HTTP `200` and the page content, confirming the new markup is present in served output.
- Attempted automated browser verification with Playwright to screenshot the Admin tab and the new panel, but the Playwright runs timed out or encountered environment routing issues and therefore failed to capture the UI screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0046f5a4c83338c5785573807a12d)