### PR TITLE
Route Operations "Log a move" submission to Supabase move_create

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,7 @@
                     >
                       Condition check required for this move.
                     </p>
+                    <p id="move-submit-status" class="field-note is-hidden"></p>
                     <button type="submit" id="move-submit">
                       Record move
                     </button>


### PR DESCRIPTION
### Motivation
- Replace the localStorage-based move write performed when submitting the Operations "Log a move" form so moves are created in the backend via the Supabase Edge Function `move_create` with proper auth and payload shape.
- Enforce shipping validation for inter-office/hire moves and provide visible submission status in the Operations console while preventing duplicate submissions.
- Use a temporary equipment UUID for now (until DB-driven equipment dropdown is wired) and keep existing localStorage history intact (stop writing new moves to it but do not remove existing data).

### Description
- Modified `handleMoveSubmit` to be `async` and send a POST to `https://eugdravtvewpnwkkpkzl.supabase.co/functions/v1/move_create` using `supabase.auth.getSession()` and `session.access_token` as `Authorization: Bearer ...`, and built the JSON payload with `equipment_id`, `move_type`, `from_location_id`, `to_location_id`, `moved_at`, `notes`, `carrier`, `tracking_number`, and `booked_at` (nullable/ISO conversions applied). 
- Added helpers/constants and small UI element to support the new flow: `moveCreateEndpoint`, `locationIdByName`, `deriveMoveType`, `toNullableValue`, `dateOnlyToISOString`, `getLocationId`, and `setMoveSubmitStatus`, plus a new DOM element `#move-submit-status` to show "Submitting move...", success, and error messages.
- Implemented shipping validation that requires `carrier` and `tracking_number` for `office_transfer`, `hire_out`, and `hire_return` moves and disabled the submit button while sending; also included a TODO and hardcoded `equipment_id` set to `f5a847d9-9f6a-4c05-9f2c-22287ee9600b` until the backend equipment list is used.
- Files changed: `src/main.js` (modified/added helper functions and replaced local submission path) and `index.html` (added `#move-submit-status` element).

### Testing
- Ran unit tests with `node --test tests/*.test.js`, which completed successfully (2 tests passed).
- Attempted an automated Playwright-based UI screenshot to verify form UI, but the browser run failed in this environment due to a Chromium process crash (not related to code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00790826083339e42f286d4f15ff0)